### PR TITLE
fix(input): 修复type值number与digit两个校验逻辑反了

### DIFF
--- a/packages/nutui/components/input/input.vue
+++ b/packages/nutui/components/input/input.vue
@@ -72,10 +72,10 @@ function updateValue(value: string, trigger: InputFormatTrigger = 'onChange') {
   if (props.maxLength && value.length > Number(props.maxLength))
     value = value.slice(0, Number(props.maxLength))
 
-  if (props.type === 'digit')
+  if (props.type === 'number')
     value = formatNumber(value, false, false)
 
-  if (props.type === 'number')
+  if (props.type === 'digit')
     value = formatNumber(value, true, true)
 
   if (props.formatter && trigger === props.formatTrigger)


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/yang1206/uniapp-nutui/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
input组件的type值：digit与number的值校验逻辑似乎是反了，在微信小程序中，number类型弹出的数字输入法不带小数点，但值校验允许输入小数点，而ditit类型的数字输入法带小数点，值却不允许输入小数点，两者的值校验逻辑在原代码中似乎反了，现已更正并在项目中被验证，若此问题无需更改请将这个pr关闭。☺️
<!-- Clear and concise description of what the PR is solving. -->

### Linked Issues

<!-- Fix #123. Fix #666. -->

### Additional Context

<!-- Any other context or screenshots about the PR here. -->