### PR TITLE
fix: (picker)修复在非h5环境下多余引入导致无法真机调试

### DIFF
--- a/packages/nutui/components/picker/picker.vue
+++ b/packages/nutui/components/picker/picker.vue
@@ -4,7 +4,9 @@ import { computed, defineComponent, reactive, ref, toRefs } from 'vue'
 import type { PickerOption } from '../pickercolumn/types'
 import { pxCheck } from '../_utils'
 import { useTranslate } from '../../locale'
+// #ifdef H5
 import NutPickerColumn from '../pickercolumn/pickercolumn.vue'
+// #endif
 import { pickerEmits, pickerProps } from './picker'
 import { componentName, usePicker } from './use-picker'
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/yang1206/uniapp-nutui/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

在非h5环境下使用picker组件，会导致无法真机调试

### Additional Context

![image](https://github.com/nutui-uniapp/nutui-uniapp/assets/52436248/b6ff42a5-e94b-4c1b-8f21-ca8a5f359e65)
小程序在使用picker组件后，就会出现此问题