### PR TITLE
fix(badge): badge的top、right不支持rpx单位

### DIFF
--- a/packages/nutui/components/badge/badge.vue
+++ b/packages/nutui/components/badge/badge.vue
@@ -2,13 +2,14 @@
 import { computed, defineComponent } from 'vue'
 import { PREFIX } from '../_constants'
 import { badgeProps } from './badge'
+import { pxCheck } from '../_utils'
 
 const props = defineProps(badgeProps)
 
 const stl = computed(() => {
   return {
-    top: `${props.top}px`,
-    right: `${props.right}px`,
+    top: pxCheck(props.top),
+    right: pxCheck(props.right),
     zIndex: props.zIndex,
     background: props.customColor,
   }


### PR DESCRIPTION
fix: badge的top、right不支持rpx单位