### PR TITLE
fix: textarea的autosize表现异常

### DIFF
--- a/packages/nutui/components/textarea/index.scss
+++ b/packages/nutui/components/textarea/index.scss
@@ -65,13 +65,4 @@
   &__ali {
     line-height: 17px;
   }
-
-  .nut-textarea__cpoytext {
-    position: absolute;
-    top: -999999px;
-    left: -999999px;
-    font-family: monospace;
-    font-size: 14px;
-    line-height: 1.5;
-  }
 }

--- a/packages/nutui/components/textarea/textarea.ts
+++ b/packages/nutui/components/textarea/textarea.ts
@@ -1,5 +1,5 @@
 import type { ExtractPropTypes, PropType } from 'vue'
-import type { ConfirmTextType, AdjustKeyboardTo } from './type'
+import type { AdjustKeyboardTo, ConfirmTextType } from './type'
 
 export const textareaProps = {
   modelValue: {
@@ -95,7 +95,7 @@ export const textareaEmits = {
   'focus': (evt: Event) => evt,
   'change': (val1?: string, val2?: string | Event) => true,
   'update:modelValue': (val1?: string, val2?: string | Event) => true,
-  'confirm': (evt: any) => evt instanceof Object,
+  'confirm': (evt: Event) => evt,
 }
 
 export type TextareaEmits = typeof textareaEmits

--- a/packages/nutui/components/textarea/textarea.vue
+++ b/packages/nutui/components/textarea/textarea.vue
@@ -1,21 +1,20 @@
 <!-- eslint-disable padded-blocks -->
 <script setup lang="ts">
-import type { CSSProperties, ComponentInternalInstance } from 'vue'
-import { computed, defineComponent, getCurrentInstance, nextTick, onMounted, ref, watch } from 'vue'
+import type { CSSProperties } from 'vue'
+import type * as CSS from 'csstype'
+import { computed, defineComponent, ref } from 'vue'
 import type { TextareaConfirmType } from '@uni-helper/uni-app-types'
-import { isH5, isMpAlipay } from '../_utils'
+import { isH5, isMpAlipay, pxCheck } from '../_utils'
 import { PREFIX } from '../_constants'
 import { useTranslate } from '../../locale'
-import { useSelectorQuery } from '../_hooks'
 import { textareaEmits, textareaProps } from './textarea'
 
 export interface InputTarget extends HTMLInputElement {
   composing?: boolean
 }
+
 const props = defineProps(textareaProps)
 const emit = defineEmits(textareaEmits)
-const instance = getCurrentInstance() as ComponentInternalInstance
-const { getSelectorNodeInfo } = useSelectorQuery(instance)
 
 const classes = computed(() => {
   const prefixCls = componentName
@@ -25,19 +24,22 @@ const classes = computed(() => {
   }
 })
 
-const styles: any = computed(() => {
-  const styleObj: { textAlign: string; height?: string } = {
-    textAlign: props.textAlign,
+const styles = computed<CSSProperties>(() => {
+  const styleObj: CSSProperties = {
+    textAlign: props.textAlign as CSS.TextAlignProperty,
   }
-  if (props.autosize)
-    styleObj.height = heightSet.value
+
+  if (typeof props.autosize === 'object') {
+    const { minHeight, maxHeight } = props.autosize
+
+    if (minHeight != null)
+      styleObj.minHeight = pxCheck(minHeight)
+
+    if (maxHeight != null)
+      styleObj.maxHeight = pxCheck(maxHeight)
+  }
 
   return styleObj
-})
-
-const copyTxtStyle = ref<CSSProperties>({
-  wordBreak: 'break-all',
-  width: '0',
 })
 
 function emitChange(value: string, event: Event) {
@@ -57,6 +59,7 @@ function change(event: any) {
     _onInput(event)
   }
 }
+
 function _onInput(event: any) {
   const input = event.detail as HTMLInputElement
   let value = input.value
@@ -89,64 +92,6 @@ function _confirm(event: any) {
   emit('confirm', event)
 }
 
-const textareaHeight = ref(20)
-const heightSet = ref('auto')
-function getContentHeight() {
-  heightSet.value = 'auto'
-  let height = textareaHeight.value
-  if (typeof props.autosize === 'object') {
-    const { maxHeight, minHeight } = props.autosize
-    if (maxHeight !== undefined)
-      height = Math.min(height, maxHeight)
-
-    if (minHeight !== undefined)
-      height = Math.max(height, minHeight)
-  }
-  if (height)
-    heightSet.value = `${height}px`
-}
-watch(
-  () => props.modelValue,
-  () => {
-    if (props.autosize) {
-      setTimeout(() => {
-        copyHeight()
-      }, 100)
-    }
-  },
-)
-
-function copyHeight() {
-  getSelectorNodeInfo('#nut-textarea__cpoytext').then((res) => {
-    if (res) {
-      if (props.modelValue === '')
-        textareaHeight.value = 20
-      else
-        textareaHeight.value = res.height || 20
-
-      nextTick(getContentHeight)
-    }
-  })
-}
-
-function getRefWidth() {
-  const query = uni.createSelectorQuery().in(instance)
-  query.select('#nut-textarea__textarea').boundingClientRect()
-  query.exec((res: any) => {
-    if (res[0])
-      copyTxtStyle.value.width = `${res[0].width}px`
-  })
-}
-onMounted(() => {
-  if (props.autosize) {
-    nextTick(() => {
-      setTimeout(() => {
-        getRefWidth()
-        copyHeight()
-      }, 300)
-    })
-  }
-})
 const composing = ref(false)
 function startComposing(event: Event) {
   if (isH5)
@@ -193,6 +138,7 @@ export default defineComponent({
       :maxlength="maxLength ? +maxLength : -1"
       :placeholder="placeholder || translate('placeholder')"
       :auto-focus="autofocus"
+      :auto-height="!!autosize"
       :cursor-spacing="cursorSpacing"
       :cursor="cursor"
       :show-confirm-bar="showConfirmBar"
@@ -210,12 +156,10 @@ export default defineComponent({
       @change="(endComposing as any)"
       @compositionend="(endComposing as any)"
       @compositionstart="(startComposing as any)"
+      @confirm="_confirm"
     />
     <view v-if="limitShow" class="nut-textarea__limit">
       {{ modelValue ? modelValue.length : 0 }}/{{ maxLength }}
-    </view>
-    <view v-if="autosize" id="nut-textarea__cpoytext" class="nut-textarea__cpoytext" :style="copyTxtStyle">
-      {{ modelValue }}
     </view>
   </view>
 </template>


### PR DESCRIPTION
当textarea启用 `autosize` 时，如果组件mounted时未展示（例如在弹窗中），那么 `getRefWidth` 获取到的 `width` 为 `0`，会导致 `nut-textarea__cpoytext` 的高度异常，从而textarea的高度也会异常。

现在直接改用uniapp的 `auto-height` 属性实现，通过 `style` 设置 `min/max Height` 以兼容原属性。