### PR TITLE
fix(textarea): 启用autosize时readonly样式不统一；fix(transition): 组件无法正常关闭；

### DIFF
--- a/packages/nutui/components/popup/popup.vue
+++ b/packages/nutui/components/popup/popup.vue
@@ -36,15 +36,15 @@ export default defineComponent({
     :duration="duration"
     :overlay-class="overlayClass"
     :overlay-style="overlayStyle"
+    :destroy-on-close="destroyOnClose"
     v-bind="$attrs"
-    :destroy-on-close="showSlot"
     @click="onClickOverlay"
   />
   <NutTransition
     :name="transitionName"
     :custom-class="classes"
     :show="visible"
-    :destroy-on-close="showSlot"
+    :destroy-on-close="destroyOnClose"
     :custom-style="popStyle"
     :duration="Number(duration)"
     @after-enter="onOpened"

--- a/packages/nutui/components/popup/use-popup.ts
+++ b/packages/nutui/components/popup/use-popup.ts
@@ -78,11 +78,8 @@ export function usePopup(props: PopupProps, emit: SetupContext<PopupEmits>['emit
 
   const onClosed = () => {
     emit(CLOSED_EVENT)
-    if (props.destroyOnClose)
-      state.showSlot = true
 
-    else
-      state.showSlot = false
+    state.showSlot = !props.destroyOnClose
   }
 
   watch(

--- a/packages/nutui/components/textarea/index.scss
+++ b/packages/nutui/components/textarea/index.scss
@@ -58,10 +58,6 @@
     }
   }
 
-  &__textarea__readonly {
-    padding: 5px 10px;
-  }
-
   &__ali {
     line-height: 17px;
   }

--- a/packages/nutui/components/textarea/textarea.vue
+++ b/packages/nutui/components/textarea/textarea.vue
@@ -123,15 +123,27 @@ export default defineComponent({
 
 <template>
   <view :class="classes" :style="customStyle">
-    <textarea v-if="props.readonly" id="nut-textarea__textarea" v-model="modelValue" :disabled="true" class="nut-textarea__textarea nut-textarea__textarea__readonly" />
+    <textarea
+      v-if="props.readonly"
+      class="nut-textarea__textarea nut-textarea__textarea__readonly"
+      :class="{ 'nut-textarea__ali': isMpAlipay }"
+      :style="styles"
+      :value="modelValue"
+      :rows="rows"
+      :disabled="true"
+      :show-count="false"
+      :placeholder="placeholder || translate('placeholder')"
+      :auto-height="!!autosize"
+      :disable-default-padding="disableDefaultPadding"
+    />
     <textarea
       v-else
-      id="nut-textarea__textarea"
-      class="nut-textarea__textarea" :class="[isMpAlipay && 'nut-textarea__ali']"
+      class="nut-textarea__textarea"
+      :class="{ 'nut-textarea__ali': isMpAlipay }"
       :style="styles"
+      :value="modelValue"
       :rows="rows"
       :disabled="disabled || readonly"
-      :value="modelValue"
       :show-count="false"
       :maxlength="maxLength ? +maxLength : -1"
       :placeholder="placeholder || translate('placeholder')"

--- a/packages/nutui/components/transition/index.scss
+++ b/packages/nutui/components/transition/index.scss
@@ -1,5 +1,5 @@
-// .nut-transition {
-//   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-//   transition-duration: 150ms;
-//   transition-property: all;
-// }
+.nut-transition {
+  &--hidden {
+    display: none !important;
+  }
+}

--- a/packages/nutui/components/transition/transition.vue
+++ b/packages/nutui/components/transition/transition.vue
@@ -22,7 +22,7 @@ export default defineComponent({
 </script>
 
 <template>
-  <block v-if="!props.destroyOnClose">
+  <template v-if="props.destroyOnClose">
     <view
       v-if="display"
       :class="classes"
@@ -31,17 +31,16 @@ export default defineComponent({
     >
       <slot />
     </view>
-  </block>
-  <block v-else>
+  </template>
+  <template v-else>
     <view
-      v-show="display"
       :class="classes"
       :style="styles"
       @click="clickHandler"
     >
       <slot />
     </view>
-  </block>
+  </template>
 </template>
 
 <style lang="scss">

--- a/packages/nutui/components/transition/use-transition.ts
+++ b/packages/nutui/components/transition/use-transition.ts
@@ -171,6 +171,7 @@ export function useTransition(props: TransitionProps, emit: SetupContext<Transit
   const classes = computed(() => {
     return getMainClass(props, componentName, {
       [animationClass.value]: true,
+      [`${componentName}--hidden`]: !display.value,
     })
   })
   const styles = computed(() => {


### PR DESCRIPTION
1、textarea启用autosize时readonly与普通状态下的样式不统一；

2、app端v-show使用display:none控制隐藏的样式优先级不足，导致transition组件无法关闭。 #142 