### PR TITLE
fix(input): 给input组件文字添加默认color,解决issues165

### DIFF
--- a/packages/nutui/components/input/index.scss
+++ b/packages/nutui/components/input/index.scss
@@ -37,6 +37,7 @@ textarea {
   padding: 10px 25px;
   font-size: $input-font-size;
   line-height: 20px;
+  color:$title-color;
   background: $white;
 
   &.center {


### PR DESCRIPTION
给input组件文字添加默认color
修复官网 https://nutui-uniapp.netlify.app/components/dentry/input.html 亮色模式下input文字不显示问题
issue: https://github.com/nutui-uniapp/nutui-uniapp/pull/156


