### PR TITLE
fix(navbar): 修复占位元素重复计算状态栏高度的问题

### DIFF
--- a/packages/nutui/components/navbar/navbar.vue
+++ b/packages/nutui/components/navbar/navbar.vue
@@ -59,7 +59,7 @@ function getNavHeight() {
 
   // #ifndef MP
   useRect('navBarHtml', instance).then((res) => {
-    navHeight.value = pxCheck(res.height! + statusBarHeight!)
+    navHeight.value = pxCheck(res.height!)
   })
   // #endif
 }


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/nutui-uniapp/nutui-uniapp/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
navBarHtml节点的css样式里面已经包含了状态栏高度,占位元素高度不需要再重复计算一次

<!-- Clear and concise description of what the PR is solving. -->

### Linked Issues

<!-- Fix #123. Fix #666. -->

### Additional Context

<!-- Any other context or screenshots about the PR here. -->