### PR TITLE
fix(transition): app端destroyOnClose属性无效

### DIFF
--- a/docs/components/basic/popup.md
+++ b/docs/components/basic/popup.md
@@ -161,7 +161,7 @@
 | closeable              | 是否显示关闭按钮                                            | boolean        | `false`        |
 | close-icon-position    | 关闭按钮位置（top-left,top-right,bottom-left,bottom-right） | string         | `"top-right"` |
 | close-icon             | [图标名称](/components/basic/icon) 或图片链接                                                  | string         | `"close"`     |
-| destroy-on-close       | 弹层关闭后 `slot`内容会不会清空, 该属性仅支持 H5与微信小程序平台                                        | boolean        | `true`        |
+| destroy-on-close       | 弹层关闭后 `slot`内容会不会清空                                        | boolean        | `true`        |
 | round                  | 是否显示圆角                                                |boolean        | `false`       |
 | overlay-class       | 自定义遮罩层类名 | string  | ''  |
 | overlay-style       | 自定义遮罩层样式  | string  | ''  |

--- a/packages/nutui/components/transition/transition.vue
+++ b/packages/nutui/components/transition/transition.vue
@@ -22,36 +22,14 @@ export default defineComponent({
 </script>
 
 <template>
-  <!-- #ifdef H5 || MP-WEIXIN -->
-  <template v-if="props.destroyOnClose">
-    <view
-      v-if="display"
-      :class="classes"
-      :style="styles"
-      @click="clickHandler"
-    >
-      <slot />
-    </view>
-  </template>
-  <template v-else>
-    <view
-      :class="classes"
-      :style="styles"
-      @click="clickHandler"
-    >
-      <slot />
-    </view>
-  </template>
-  <!-- #endif -->
-  <!-- #ifndef H5 || MP-WEIXIN -->
-  <div
-    v-show="display" :class="[classes, props.customClass]"
+  <view
+    v-if="!props.destroyOnClose || display"
+    :class="classes"
     :style="styles"
     @click="clickHandler"
   >
     <slot />
-  </div>
-  <!-- #endif -->
+  </view>
 </template>
 
 <style lang="scss">


### PR DESCRIPTION
`nut-transition`及衍生组件在app端destroyOnClose属性无效