### PR TITLE
refactor(input): 统一input类型命名规则

### DIFF
--- a/packages/nutui/components/input/input.ts
+++ b/packages/nutui/components/input/input.ts
@@ -2,7 +2,7 @@ import type { ExtractPropTypes, PropType } from 'vue'
 import type { InputOnBlurEvent, InputOnConfirmEvent, InputOnFocusEvent, InputOnInputEvent } from '@uni-helper/uni-app-types'
 import { commonProps, isNumber, isString, makeNumberProp, makeNumericProp, makeStringProp, truthProp } from '../_utils'
 import { BLUR_EVENT, CLEAR_EVENT, CLICK_EVENT, CONFIRM_EVENT, FOCUS_EVENT, INPUT_EVENT, UPDATE_MODEL_EVENT } from '../_constants'
-import type { ConfirmTextType, InputAlignType, InputFormatTrigger, InputMode, InputType } from './type'
+import type { InputAlignType, InputConfirmType, InputFormatTrigger, InputMode, InputType } from './type'
 
 export const inputProps = {
   ...commonProps,
@@ -84,7 +84,7 @@ export const inputProps = {
   /**
    * @description 键盘右下角按钮的文字，仅在`type='text'`时生效,可选值 `send`：发送、`search`：搜索、`next`：下一个、`go`：前往、`done`：完成
    */
-  confirmType: makeStringProp<ConfirmTextType>('done'),
+  confirmType: makeStringProp<InputConfirmType>('done'),
   /**
    * @description  键盘弹起时，是否自动上推页面
    */

--- a/packages/nutui/components/input/type.ts
+++ b/packages/nutui/components/input/type.ts
@@ -1,20 +1,25 @@
 export const inputAlignType = ['left', 'center', 'right'] as const // text-align
 export type InputAlignType = (typeof inputAlignType)[number]
+
 export const inputFormatTrigger = ['onChange', 'onBlur'] as const // onChange: 在输入时执行格式化 ; onBlur: 在失焦时执行格式化
 export type InputFormatTrigger = (typeof inputFormatTrigger)[number]
+
 export const inputType
   = ['tel', 'url', 'date', 'file', 'text', 'time', 'week', 'color', 'digit', 'email', 'image', 'month', 'radio', 'range', 'reset', 'button', 'hidden', 'number', 'search', 'submit', 'checkbox', 'password', 'textarea', 'datetime-local', 'idcard', 'safe-password', 'nickname'] as const
 export type InputType = (typeof inputType)[number]
+
 export const uniInputType = ['text', 'number', 'idcard', 'digit', 'tel', 'safe-password', 'nickname'] as const
 export type UniInputType = (typeof uniInputType)[number]
+
 export interface InputRule {
   pattern?: RegExp
   message?: string
   required?: boolean
 }
 
-export const confirmTextType = ['send', 'search', 'next', 'go', 'done'] as const
-export type ConfirmTextType = (typeof confirmTextType)[number]
+export const inputConfirmType = ['send', 'search', 'next', 'go', 'done'] as const
+export type InputConfirmType = (typeof inputConfirmType)[number]
+
 export interface InputTarget extends HTMLInputElement {
   composing?: boolean
 }


### PR DESCRIPTION
`nut-input` 统一input类型命名规则