### PR TITLE
fix(picker): 修复微信小程序暗黑模式picker背景颜色显示错误的问题

### DIFF
--- a/packages/nutui/components/picker/index.scss
+++ b/packages/nutui/components/picker/index.scss
@@ -34,6 +34,13 @@
   background: #fff;
   border-radius: 5px;
 
+  /* #ifndef H5 */
+  &__mask {
+    background: none !important;
+  }
+
+  /* #endif */
+
   // 标题
   &__bar {
     display: flex;

--- a/packages/nutui/components/picker/picker.vue
+++ b/packages/nutui/components/picker/picker.vue
@@ -195,6 +195,7 @@ export default defineComponent({
       :value="defaultIndexes"
       :style="pickerViewStyles"
       :immediate-change="true"
+      mask-class="nut-picker__mask"
       @change="tileChange"
       @pickstart="handlePickstart"
       @pickend="handlePickend"


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/nutui-uniapp/nutui-uniapp/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
微信小程序`picker-view`有默认的蒙层样式,通过`mask-class`去除默认蒙层样式
<!-- Clear and concise description of what the PR is solving. -->

### Linked Issues
#235 
<!-- Fix #123. Fix #666. -->

### Additional Context

<!-- Any other context or screenshots about the PR here. -->