### PR TITLE
fix(elevator): 修复app端点击索引无效，并且滚动页面索引无法跟随切换问题

### DIFF
--- a/packages/nutui/components/elevator/elevator.vue
+++ b/packages/nutui/components/elevator/elevator.vue
@@ -75,15 +75,21 @@ async function calculateHeight() {
   state.listHeight = []
   let height = 0
   state.listHeight.push(height)
-  const nodeList: any = await Promise.all(
-    state.listGroup.map(async (_, index) => {
-      return await queryItemHeight(index)
-    }),
-  )
-  nodeList.forEach((_: any, index: number) => {
-    height += Math.floor((nodeList[index][0] as any).height)
-    state.listHeight.push(height)
-  })
+  try {
+    const nodeList: any = await Promise.all(
+      state.listGroup.map(async (_, index) => {
+        return await queryItemHeight(index)
+      }),
+    )
+    nodeList.forEach((_: any, index: number) => {
+      height += Math.floor((nodeList[index][0] as any).height)
+      state.listHeight.push(height)
+    })
+  }
+  catch (err) {
+    state.listHeight = [0]
+    throw err
+  }
 }
 
 function scrollTo(index: number) {
@@ -163,13 +169,19 @@ function queryItemHeightFields(index: number) {
 }
 
 onMounted(async () => {
-  await Promise.all(
-    props.indexList.map(async (_, index) => {
-      const data = await queryItemHeightFields(index)
-      setListGroup(data)
-    }),
-  )
-  calculateHeight()
+  try {
+    await Promise.all(
+      props.indexList.map(async (_, index) => {
+        const data = await queryItemHeightFields(index)
+        setListGroup(data)
+      }),
+    )
+    calculateHeight()
+  }
+  catch (err) {
+    calculateHeight()
+    throw err
+  }
 })
 
 watch(

--- a/packages/nutui/components/elevator/elevator.vue
+++ b/packages/nutui/components/elevator/elevator.vue
@@ -59,17 +59,31 @@ function setListGroup(el: any) {
   })
 }
 
-function calculateHeight() {
+function queryItemHeight(index: number) {
+  return new Promise((resolve) => {
+    uni.createSelectorQuery()
+      .in(instance)
+      .selectAll(`#elevator__item__${index}`)
+      .boundingClientRect((res: any) => {
+        resolve(res)
+      })
+      .exec()
+  })
+}
+
+async function calculateHeight() {
   state.listHeight = []
   let height = 0
   state.listHeight.push(height)
-  for (let i = 0; i < state.listGroup.length; i++) {
-    state.query.in(instance).selectAll(`#elevator__item__${i}`).boundingClientRect()
-    state.query.exec((res: { height: number }[][]) => {
-      height += Math.floor(res[i][0].height)
-      state.listHeight.push(height)
-    })
-  }
+  const nodeList: any = await Promise.all(
+    state.listGroup.map(async (_, index) => {
+      return await queryItemHeight(index)
+    }),
+  )
+  nodeList.forEach((_: any, index: number) => {
+    height += Math.floor((nodeList[index][0] as any).height)
+    state.listHeight.push(height)
+  })
 }
 
 function scrollTo(index: number) {
@@ -132,8 +146,8 @@ function listViewScroll(e: any) {
   }
 }
 
-onMounted(() => {
-  props.indexList.forEach((item, index) => {
+function queryItemHeightFields(index: number) {
+  return new Promise((resolve) => {
     const query = uni.createSelectorQuery()
       .in(instance)
       .select(`#elevator__item__${index}`)
@@ -143,17 +157,20 @@ onMounted(() => {
       rect: true,
       id: true,
     }, (data) => {
-      setListGroup(data)
+      resolve(data)
     }).exec()
   })
-})
+}
 
-watch(
-  () => state.listGroup.length,
-  (val) => {
-    nextTick(calculateHeight)
-  },
-)
+onMounted(async () => {
+  await Promise.all(
+    props.indexList.map(async (_, index) => {
+      const data = await queryItemHeightFields(index)
+      setListGroup(data)
+    }),
+  )
+  calculateHeight()
+})
 
 watch(
   () => state.currentIndex,


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/nutui-uniapp/nutui-uniapp/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

修复app端点击索引无效，并且滚动页面索引无法跟随切换问题

### Linked Issues
Fix #73 
<!-- Fix #123. Fix #666. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **功能改进**
    - 优化了电梯组件的高度计算逻辑，提高了模块化和可读性。
    - 引入了新的方法以更有效地查询项目高度。
    - 更新了高度计算和列表分组的逻辑，采用了Promise和async/await以实现更好的控制流。
    - 在组件挂载时的初始化逻辑中，使用了新的方法以提升性能和效率。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->