### PR TITLE
fix(sku): 修复默认底部按钮不显示的问题

### DIFF
--- a/example/src/pages/demo/business/sku/index.vue
+++ b/example/src/pages/demo/business/sku/index.vue
@@ -189,16 +189,12 @@ export default defineComponent({
       v-model:visible="base"
       :goods="goodsInfo"
       :sku="skuData"
+      :btn-options="['cart', 'buy']"
       @select-sku="selectSku"
       @close="close"
     >
       <template #skuHeader>
         <nut-sku-header :goods="goodsInfo" />
-      </template>
-      <template #skuOperate>
-        <nut-sku-operate
-          @click-btn-operate="clickBtnOperate"
-        />
       </template>
     </nut-sku>
 

--- a/packages/nutui/components/sku/sku.vue
+++ b/packages/nutui/components/sku/sku.vue
@@ -86,6 +86,8 @@ function close() {
   emit(UPDATE_VISIBLE_EVENT, false)
 }
 const getSlots = (name: string) => slots[name]
+
+const hasSkuOperateSlot = getSlots('skuOperate') != null
 </script>
 
 <script lang="ts">
@@ -141,6 +143,7 @@ export default defineComponent({
       <SkuOperate
         :btn-extra-text="btnExtraText" :btn-options="btnOptions" :buy-text="buyText || translate('buyNow')"
         :add-cart-text="addCartText || translate('addToCart')" :confirm-text="confirmText || translate('confirm')"
+        :show-default-operate="!hasSkuOperateSlot"
         @click-btn-operate="clickBtnOperate"
       >
         <template #operateBtn>

--- a/packages/nutui/components/skuoperate/skuoperate.vue
+++ b/packages/nutui/components/skuoperate/skuoperate.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { PropType } from 'vue'
-import { defineComponent, useSlots } from 'vue'
+import { defineComponent } from 'vue'
 import { CLICK_EVENT, PREFIX } from '../_constants'
 
 const props = defineProps({
@@ -29,10 +29,14 @@ const props = defineProps({
     type: String,
     default: '确定',
   },
+
+  showDefaultOperate: {
+    type: Boolean,
+    default: true,
+  },
 })
 
 const emit = defineEmits([CLICK_EVENT, 'changeSku', 'changeBuyCount', 'clickBtnOperate'])
-const slots = useSlots()
 
 function getBtnDesc(type: string) {
   const mapD: { [props: string]: string } = {
@@ -43,8 +47,6 @@ function getBtnDesc(type: string) {
 
   return mapD[type]
 }
-
-const getSlots = (name: string) => slots[name]
 
 function clickBtnOperate(btn: string) {
   emit('clickBtnOperate', btn)
@@ -72,7 +74,7 @@ export default defineComponent ({
 
     <slot name="operateBtn" />
 
-    <view v-if="!getSlots('operateBtn')" class="nut-sku-operate-btn">
+    <view v-if="showDefaultOperate" class="nut-sku-operate-btn">
       <view
         v-for="(btn, i) in btnOptions" :key="i" class="nut-sku-operate-btn-item" :class="[`nut-sku-operate-btn-${btn}`]"
         @click="clickBtnOperate(btn)"


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/nutui-uniapp/nutui-uniapp/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Clear and concise description of what the PR is solving. -->

### Linked Issues
#218 
<!-- Fix #123. Fix #666. -->

### Additional Context

<!-- Any other context or screenshots about the PR here. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 在商品SKU组件中新增了自定义操作按钮的功能，允许用户选择加入购物车或直接购买。
- **优化**
	- 优化了SKU操作组件的显示逻辑，现在可以根据需要选择是否显示默认操作。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->