### PR TITLE
fix(sku): 修复组件内容超出,出现横向滚动条的问题

### DIFF
--- a/packages/nutui/components/sku/index.scss
+++ b/packages/nutui/components/sku/index.scss
@@ -17,10 +17,14 @@
 
   &-content {
     flex: 1;
-    padding: 0 18px;
     margin-top: 24px;
-    overflow-x: hidden;
-    overflow-y: auto;
+    overflow: hidden auto;
+
+    &-wrapper {
+      box-sizing: border-box;
+      width: 100%;
+      padding: 0 18px;
+    }
 
     &::-webkit-scrollbar {
       display: none;

--- a/packages/nutui/components/sku/sku.vue
+++ b/packages/nutui/components/sku/sku.vue
@@ -122,20 +122,22 @@ export default defineComponent({
       </slot>
 
       <scroll-view scroll-y class="nut-sku-content">
-        <slot name="skuSelectTop" />
+        <view class="nut-sku-content-wrapper">
+          <slot name="skuSelectTop" />
 
-        <slot name="skuSelect" />
-        <SkuSelect v-if="!getSlots('sku-select')" :sku="sku" @select-sku="selectSku" />
+          <slot name="skuSelect" />
+          <SkuSelect v-if="!getSlots('sku-select')" :sku="sku" @select-sku="selectSku" />
 
-        <slot name="skuStepper">
-          <SkuStepper
-            :goods="goods" :stepper-title="stepperTitle || translate('buyNumber')"
-            :stepper-max="stepperMax" :stepper-min="stepperMin" :stepper-extra-text="stepperExtraText" @add="add"
-            @reduce="reduce" @change-stepper="changeStepper" @over-limit="stepperOverLimit"
-          />
-        </slot>
+          <slot name="skuStepper">
+            <SkuStepper
+              :goods="goods" :stepper-title="stepperTitle || translate('buyNumber')"
+              :stepper-max="stepperMax" :stepper-min="stepperMin" :stepper-extra-text="stepperExtraText" @add="add"
+              @reduce="reduce" @change-stepper="changeStepper" @over-limit="stepperOverLimit"
+            />
+          </slot>
 
-        <slot name="skuStepperBottom" />
+          <slot name="skuStepperBottom" />
+        </view>
       </scroll-view>
 
       <SkuOperate


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/nutui-uniapp/nutui-uniapp/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
内容盒模型为`content-box`,导致宽度加padding超出屏幕,出现横向滚动条,并且导致插槽内容超出

![image](https://github.com/nutui-uniapp/nutui-uniapp/assets/53939074/0ce588e9-6037-4aa5-9f9c-9a7c151a6e1d)

<!-- Clear and concise description of what the PR is solving. -->

### Linked Issues

#239 

<!-- Fix #123. Fix #666. -->

### Additional Context

<!-- Any other context or screenshots about the PR here. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **样式更新**
	- 为SKU组件内容包装器调整样式属性，将内边距移至新的包装器元素，修改溢出属性为“隐藏自动”。
	- 在SKU组件中添加了“nut-sku-content-wrapper”类的`<view>`元素来包含“skuSelectTop”、“skuSelect”、“skuStepper”和“skuStepperBottom”插槽，重构了滚动视图内的布局。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->