### PR TITLE
fix(picker): 修复ts类型错误

### DIFF
--- a/packages/nutui/components/picker/picker.ts
+++ b/packages/nutui/components/picker/picker.ts
@@ -8,7 +8,7 @@ export const pickerProps = {
   /**
    * @description 默认选中项
    */
-  modelValue: makeArrayProp<(string | number)[]>([]),
+  modelValue: makeArrayProp<(string | number)>([]),
   /**
    * @description 设置标题
    */
@@ -24,7 +24,7 @@ export const pickerProps = {
   /**
    * @description 对象数组，配置每一列显示的数据
    */
-  columns: makeArrayProp<(PickerOption | PickerOption[])[]>([]),
+  columns: makeArrayProp<(PickerOption | PickerOption[])>([]),
   /**
    * @description 是否开启3D效果
    */

--- a/packages/nutui/components/picker/use-picker.ts
+++ b/packages/nutui/components/picker/use-picker.ts
@@ -7,6 +7,7 @@ const DEFAULT_FILED_NAMES = {
   text: 'text',
   value: 'value',
   children: 'children',
+  className: '',
 }
 
 export const componentName = `${PREFIX}-picker`

--- a/packages/nutui/components/pickercolumn/types.ts
+++ b/packages/nutui/components/pickercolumn/types.ts
@@ -27,5 +27,5 @@ export interface PickerFieldNames {
   text?: string
   value?: string
   children?: string
-  className: string
+  className?: string
 }


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/nutui-uniapp/nutui-uniapp/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Clear and concise description of what the PR is solving. -->

### Linked Issues

<!-- Fix #123. Fix #666. -->

### Additional Context

<!-- Any other context or screenshots about the PR here. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **功能改进**
	- 优化选择器组件的类型定义，包括使 `className` 属性在 `PickerFieldNames` 接口中变为可选。
	- 在默认字段名中添加了 `className` 字段，并设置为空字符串的默认值。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->