### PR TITLE
fix(picker): 修复model-value值污染问题

### DIFF
--- a/packages/nutui/components/_utils/common.ts
+++ b/packages/nutui/components/_utils/common.ts
@@ -1,4 +1,4 @@
-import { isDef, isObject } from './is'
+import { isArray, isDef, isObject } from './is'
 
 // 变量类型判断
 export function TypeOfFun(value: any) {
@@ -196,4 +196,81 @@ export function noop() { }
 
 export function getRandomId() {
   return Math.random().toString(36).slice(-8)
+}
+
+export function isLooseEqual(a: any, b: any): boolean {
+  if (a === b)
+    return true
+
+  const isObjectA = isObject(a)
+  const isObjectB = isObject(b)
+
+  if (isObjectA && isObjectB)
+    return JSON.stringify(a) === JSON.stringify(b)
+  else if (!isObjectA && !isObjectB)
+    return String(a) === String(b)
+  else
+    return false
+}
+
+export function isEqualArray(a: any, b: any): boolean {
+  if (a === b)
+    return true
+
+  if (!isArray(a) || !isArray(b))
+    return false
+
+  if (a.length !== b.length)
+    return false
+
+  for (let i = 0; i < a.length; i++) {
+    if (!isLooseEqual(a[i], b[i]))
+      return false
+  }
+
+  return true
+}
+
+export function isEqualValue(a: any, b: any): boolean {
+  if (a === b)
+    return true
+
+  if (isArray(a) && isArray(b))
+    return isEqualArray(a, b)
+
+  return isLooseEqual(a, b)
+}
+
+export function cloneDeep<T = any>(obj: T, cache = new WeakMap()): T {
+  if (obj === null || typeof obj !== 'object')
+    return obj
+  if (cache.has(obj))
+    return cache.get(obj)
+  let clone
+  if (obj instanceof Date) {
+    clone = new Date(obj.getTime())
+  }
+  else if (obj instanceof RegExp) {
+    clone = new RegExp(obj)
+  }
+  else if (obj instanceof Map) {
+    clone = new Map(Array.from(obj, ([key, value]) => [key, cloneDeep(value, cache)]))
+  }
+  else if (obj instanceof Set) {
+    clone = new Set(Array.from(obj, value => cloneDeep(value, cache)))
+  }
+  else if (Array.isArray(obj)) {
+    clone = obj.map(value => cloneDeep(value, cache))
+  }
+  else if (Object.prototype.toString.call(obj) === '[object Object]') {
+    clone = Object.create(Object.getPrototypeOf(obj))
+    cache.set(obj, clone)
+    for (const [key, value] of Object.entries(obj))
+      clone[key] = cloneDeep(value, cache)
+  }
+  else {
+    clone = Object.assign({}, obj)
+  }
+  cache.set(obj, clone)
+  return clone
 }

--- a/packages/nutui/components/countup/countup.vue
+++ b/packages/nutui/components/countup/countup.vue
@@ -2,7 +2,7 @@
 import { computed, defineComponent, nextTick, onMounted, onUnmounted, reactive, watch } from 'vue'
 import { PREFIX } from '../_constants'
 import { useExtend } from '../_hooks'
-import { getMainClass } from '../_utils'
+import { cloneDeep, getMainClass } from '../_utils'
 import { type IData, countupEmits, countupProps } from './countup'
 
 const props = defineProps(countupProps)
@@ -408,7 +408,7 @@ function scrollTime(index: number, total: number, num: number) {
       if (data.finshMachine === props.machineNum) {
         const distance = props.numHeight * props.machinePrizeNum
         data.prizeYPrev = []
-        const prevAry = JSON.parse(JSON.stringify(data.prizeY))
+        const prevAry = cloneDeep(data.prizeY)
         prevAry.forEach((item: any) => {
           let n = item
           while (n > distance)

--- a/packages/nutui/components/datepicker/datepicker.vue
+++ b/packages/nutui/components/datepicker/datepicker.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, defineComponent, nextTick, onBeforeMount, reactive, watch } from 'vue'
-import { isDate as isDateU, padZero } from '../_utils'
+import { isDate as isDateU, isEqualValue, padZero } from '../_utils'
 import { CANCEL_EVENT, CONFIRM_EVENT, PREFIX, UPDATE_MODEL_EVENT } from '../_constants'
 import NutPicker from '../picker/picker.vue'
 import type { PickerOption } from '../pickercolumn'
@@ -271,8 +271,7 @@ watch(
   () => props.modelValue,
   (value) => {
     const newValues = formatValue(value as Date)
-    const isSameValue = JSON.stringify(newValues) === JSON.stringify(state.currentDate)
-    if (!isSameValue) {
+    if (!isEqualValue(newValues, state.currentDate)) {
       state.currentDate = newValues
       state.selectedValue = getSelectedValue(newValues)
     }
@@ -282,8 +281,7 @@ watch(
 watch(
   () => state.currentDate,
   (newValues) => {
-    const isSameValue = JSON.stringify(newValues) === JSON.stringify(props.modelValue)
-    if (!isSameValue) {
+    if (!isEqualValue(newValues, props.modelValue)) {
       emit(UPDATE_MODEL_EVENT, newValues)
       nextTick(() => {
         state.selectedValue = getSelectedValue(newValues)

--- a/packages/nutui/components/guessgift/guessgift.vue
+++ b/packages/nutui/components/guessgift/guessgift.vue
@@ -2,7 +2,7 @@
 import { type ComponentInternalInstance, computed, defineComponent, getCurrentInstance, onMounted, reactive, ref, watch } from 'vue'
 import { PREFIX } from '../_constants'
 import { useRect, useSelectorQuery } from '../_hooks'
-import { getMainClass, getRandomId } from '../_utils'
+import { cloneDeep, getMainClass, getRandomId } from '../_utils'
 import { guessgiftEmits, guessgiftProps } from './guessgift'
 
 const props = defineProps(guessgiftProps)
@@ -43,9 +43,9 @@ const classes = computed(() => {
 })
 
 // 打乱数组顺序
-const shuffleNewary = ref([])
+const shuffleNewary = ref<any[]>([])
 function shuffle(ary: Array<any>) {
-  const array = JSON.parse(JSON.stringify(ary))
+  const array = cloneDeep(ary)
   for (let i = array.length - 1; i > 0; i--) {
     const j = Math.floor(Math.random() * (i + 1));
     [array[i], array[j]] = [array[j], array[i]]

--- a/packages/nutui/components/picker/use-picker.ts
+++ b/packages/nutui/components/picker/use-picker.ts
@@ -1,7 +1,7 @@
 import { computed, reactive, ref, toRefs, watch } from 'vue'
 import type { PickerFieldNames, PickerOption } from '../pickercolumn/types'
 import { CANCEL_EVENT, CHANGE_EVENT, CONFIRM_EVENT, PREFIX, UPDATE_MODEL_EVENT } from '../_constants'
-import { cloneDeep, getMainClass } from '../_utils'
+import { cloneDeep, getMainClass, isEqualValue } from '../_utils'
 
 const DEFAULT_FILED_NAMES = {
   text: 'text',
@@ -168,8 +168,6 @@ export function usePicker(props: any, emit: any) {
     })
   }
 
-  const isSameValue = (valA: any, valB: any) => JSON.stringify(valA) === JSON.stringify(valB)
-
   const confirmHandler = () => {
     pickerColumn.value.length > 0
     && pickerColumn.value.forEach((column) => {
@@ -182,7 +180,7 @@ export function usePicker(props: any, emit: any) {
   watch(
     () => props.modelValue,
     (newValues) => {
-      if (!isSameValue(newValues, defaultValues.value))
+      if (!isEqualValue(newValues, defaultValues.value))
         defaultValues.value = cloneDeep(newValues)
     },
     { deep: true, immediate: true },
@@ -191,7 +189,7 @@ export function usePicker(props: any, emit: any) {
   watch(
     defaultValues,
     (newValues) => {
-      if (!isSameValue(newValues, props.modelValue))
+      if (!isEqualValue(newValues, props.modelValue))
         emit(UPDATE_MODEL_EVENT, newValues)
     },
     { deep: true },
@@ -219,6 +217,5 @@ export function usePicker(props: any, emit: any) {
     pickerColumn,
     swipeRef,
     selectedOptions,
-    isSameValue,
   }
 }

--- a/packages/nutui/components/picker/use-picker.ts
+++ b/packages/nutui/components/picker/use-picker.ts
@@ -1,7 +1,7 @@
 import { computed, reactive, ref, toRefs, watch } from 'vue'
 import type { PickerFieldNames, PickerOption } from '../pickercolumn/types'
 import { CANCEL_EVENT, CHANGE_EVENT, CONFIRM_EVENT, PREFIX, UPDATE_MODEL_EVENT } from '../_constants'
-import { getMainClass } from '../_utils'
+import { cloneDeep, getMainClass } from '../_utils'
 
 const DEFAULT_FILED_NAMES = {
   text: 'text',
@@ -183,7 +183,7 @@ export function usePicker(props: any, emit: any) {
     () => props.modelValue,
     (newValues) => {
       if (!isSameValue(newValues, defaultValues.value))
-        defaultValues.value = newValues
+        defaultValues.value = cloneDeep(newValues)
     },
     { deep: true, immediate: true },
   )

--- a/packages/nutui/components/range/range.vue
+++ b/packages/nutui/components/range/range.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { type CSSProperties, type ComponentInternalInstance, computed, defineComponent, getCurrentInstance, nextTick, onMounted, ref, toRef } from 'vue'
-import { getRandomId, isH5, preventDefault } from '../_utils'
+import { getRandomId, isEqualValue, isH5, preventDefault } from '../_utils'
 import { CHANGE_EVENT, PREFIX, UPDATE_MODEL_EVENT } from '../_constants'
 import { useRect, useTouch } from '../_hooks'
 import { useFormDisabled } from '../form/form'
@@ -151,10 +151,6 @@ function format(value: number) {
   return Math.round(value / +step) * +step
 }
 
-function isSameValue(newValue: SliderValue, oldValue: SliderValue) {
-  return JSON.stringify(newValue) === JSON.stringify(oldValue)
-}
-
 function handleOverlap(value: number[]) {
   if (value[0] > value[1])
     return value.slice(0).reverse()
@@ -168,10 +164,10 @@ function updateValue(value: SliderValue, end?: boolean) {
   else
     value = format(value)
 
-  if (!isSameValue(value, props.modelValue))
+  if (!isEqualValue(value, props.modelValue))
     emit(UPDATE_MODEL_EVENT, value)
 
-  if (end && !isSameValue(value, startValue))
+  if (end && !isEqualValue(value, startValue))
     emit(CHANGE_EVENT, value)
 }
 


### PR DESCRIPTION
`nut-picker` 修复model-value值污染问题

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 增加了数组深度克隆和值比较的工具函数，提高了数据处理的准确性和效率。

- **改进**
	- 在`countup`组件中，使用`cloneDeep`函数替换了`JSON.parse(JSON.stringify(...))`进行深度克隆数组，优化了性能。
	- `datepicker`组件现在使用值等价性检查函数替换了直接的JSON字符串比较，增强了日期值更新和同步的逻辑。
	- `guessgift`组件中，`shuffle`函数现在使用`cloneDeep`来克隆数组，提高了数据操作的安全性和效率。
	- `picker`组件的逻辑更新，包括使用`cloneDeep`和`isEqualValue`函数替换了原有的深度比较和默认值设置方法，增强了数据处理的准确性。
	- `range`组件现在使用`isEqualValue`函数而不是之前的`isSameValue`函数来比较值，优化了值变化时的事件更新和触发逻辑。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->