### PR TITLE
chore: 移除demo中的Locale.merge示例

### DIFF
--- a/example/src/main.ts
+++ b/example/src/main.ts
@@ -1,16 +1,11 @@
 import { createSSRApp } from 'vue'
 
-import { Locale } from 'nutui-uniapp/locale'
 import App from './App.vue'
 import 'uno.css'
 import './main.scss'
 import { setupStore } from './store'
 import './styles/app.scss'
 import '@nutui/touch-emulator'
-
-Locale.merge({
-  confirm: '已确认',
-})
 
 export function createApp() {
   const app = createSSRApp(App)


### PR DESCRIPTION
移除demo中的Locale.merge示例，文档中有说明即可，无需在demo中体现影响观感

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **优化**
	- 移除了对 `nutui-uniapp/locale` 的 `Locale` 导入及其 `merge` 方法的调用。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->