### PR TITLE
chore: 更换文档域名

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -8,7 +8,7 @@ body:
 
         这个表单仅用于错误报告。对于在使用中遇到的问题，请优先使用以下方式寻找解决方案：
 
-        - 查看组件文档 [nutui-uniapp](https://nutui-uniapp.netlify.app)
+        - 查看组件文档 [nutui-uniapp](https://uniapp-nutui.tech)
         - 在 [Issue](https://github.com/nutui-uniapp/nutui-uniapp/issues) 列表中查找解决方案
         - 查看 [常见问题 QA](https://github.com/nutui-uniapp/nutui-uniapp/issues/2461)
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: 🤖 常见问题 QA
-    url: https://nutui-uniapp.netlify.app/guide/faq.html
+    url: https://uniapp-nutui.tech/guide/faq.html
     about: 这里可能会有解决方案。

--- a/.github/ISSUE_TEMPLATE/feature_request_template.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request_template.yml
@@ -10,7 +10,7 @@ body:
 
         这个表单仅用于新功能请求。如果你有使用上的问题，或者不确定它是否是一个 bug，请先：
 
-        - 查看组件文档 [nutui-uniapp](https://nutui-uniapp.netlify.app/)
+        - 查看组件文档 [nutui-uniapp](https://uniapp-nutui.tech/)
         - 在 [Issue](https://github.com/nutui-uniapp/nutui-uniapp/issues) 列表中查找解决方案
         - 查看 [常见问题 QA](https://github.com/nutui-uniapp/nutui-uniapp/issues/2461)
   - type: textarea

--- a/README.md
+++ b/README.md
@@ -47,13 +47,13 @@ nutui-uniapp 组件库，基于Taro版[`NutUi`](https://nutui.jd.com/#/) 4.x版�
 
 ## 快速开始
 
-请参考[快速开始](https://nutui-uniapp.netlify.app/guide/quick-start.html)。
+请参考[快速开始](https://uniapp-nutui.tech/guide/quick-start.html)。
 
 ## 链接
 
 - [意见反馈](https://github.com/nutui-uniapp/nutui-uniapp/issues)
 - [更新日志](https://github.com/nutui-uniapp/nutui-uniapp/releases)
-- [常见问题](https://nutui-uniapp.netlify.app/guide/faq.html)
+- [常见问题](https://uniapp-nutui.tech/guide/faq.html)
 - [Discussions 讨论区](https://github.com/nutui-uniapp/nutui-uniapp/discussions)
 
 ## 贡献指南

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -31,7 +31,7 @@ export default withPwa(defineConfig({
       { text: '组件', items: navComponents },
       {
         text: '示例',
-        link: 'https://nutui-uniapp.netlify.app/ui',
+        link: 'https://uniapp-nutui.tech/ui',
       },
       {
         text: '其他',

--- a/packages/nutui/README.md
+++ b/packages/nutui/README.md
@@ -47,13 +47,13 @@ nutui-uniapp 组件库，基于Taro版[`NutUi`](https://nutui.jd.com/#/) 4.x版�
 
 ## 快速开始
 
-请参考[快速开始](https://nutui-uniapp.netlify.app/guide/quick-start.html)。
+请参考[快速开始](https://uniapp-nutui.tech/guide/quick-start.html)。
 
 ## 链接
 
 - [意见反馈](https://github.com/nutui-uniapp/nutui-uniapp/issues)
 - [更新日志](https://github.com/nutui-uniapp/nutui-uniapp/releases)
-- [常见问题](https://nutui-uniapp.netlify.app/guide/faq.html)
+- [常见问题](https://uniapp-nutui.tech/guide/faq.html)
 - [Discussions 讨论区](https://github.com/nutui-uniapp/nutui-uniapp/discussions)
 
 ## 贡献指南


### PR DESCRIPTION
nutui-uniapp.netlify.app 经常打不开

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **文档更新**
  - 更新了Bug报告和功能请求模板中的文档链接，指向新的文档地址。
  - 更新了`README.md`文件和`nutui`包内文档链接，将“快速开始”和“常见问题”部分的URL从旧域名更改为`uniapp-nutui.tech`。
  - 在导航部分更新了一个链接，从`https://nutui-uniapp.netlify.app/ui`更改为`https://uniapp-nutui.tech/ui`。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->