### PR TITLE
chore: 重新编写快速上手文档

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ nutui-uniapp 组件库，基于Taro版[`NutUi`](https://nutui.jd.com/#/) 4.x版�
 - 🍭 支持暗黑模式
 - 🌍 支持国际化
 
-## 快速开始
+## 快速上手
 
-请参考[快速开始](https://uniapp-nutui.tech/guide/quick-start.html)。
+请参考[快速上手](https://uniapp-nutui.tech/guide/quick-start.html)。
 
 ## 链接
 

--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -18,7 +18,7 @@
 :::
 
 ::: details cli样式引入无效
-请详细参考文档  [快速开始](/guide/quick-start)
+请详细参考文档  [快速上手](/guide/quick-start)
 :::
 
 ::: details 某些组件在小程序有一些问题，仅支持 H5

--- a/docs/guide/overview.md
+++ b/docs/guide/overview.md
@@ -4,7 +4,7 @@
 
 nutui-uniapp 组件库，基于Taro版[`NutUi`](https://nutui.jd.com) 4.x版本修改而来，适配了uni-app, 使用 Vue 技术栈开发小程序应用，开箱即用，拥有丰富的业务组件。
 
-使用请参考[快速开始](./quick-start.md)。
+使用请参考[快速上手](./quick-start.md)。
 
 ## 特性
 

--- a/docs/guide/quick-start.md
+++ b/docs/guide/quick-start.md
@@ -1,189 +1,237 @@
-# 快速开始
+# 快速上手
 
-> nutui-uniapp 提供了 npm 包和 uni_modules 包两种方式使用组件。
-::: warning
-为了能够获得良好的开发体验，强烈建议使用[cli](https://uniapp.dcloud.net.cn/quickstart-cli.html#install-vue-cli)创建项目。
+> nutui-uniapp 提供了 `npm` 和 `uni_modules` 两种方式使用组件。
+
+::: warning 提示
+为了能够获得良好的开发体验，强烈建议使用[CLI](https://uniapp.dcloud.net.cn/quickstart-cli.html#install-vue-cli)创建项目。
 :::
 
-## npm 安装 (cli)
+## NPM方式
 
- ::: code-group
+### 安装
 
-  ```bash [pnpm]
-  pnpm add nutui-uniapp
-  ```
+---
 
-  ```bash [yarn]
-  yarn add nutui-uniapp
-  ```
+::: code-group
 
-  ```bash [npm]
-  npm install nutui-uniapp
-  ```
+```bash [pnpm]
+pnpm add nutui-uniapp
+```
 
-  :::
+```bash [yarn]
+yarn add nutui-uniapp
+```
 
-### 配置 nutui-uniapp
+```bash [npm]
+npm install nutui-uniapp
+```
 
-### 按需导入
+:::
 
-像下面这样更新 `pages.json` 文件：
+### 配置
 
-```json
-// pages.json
-{
-  "easycom": {
-    "autoscan": true,
-    "custom": {
-      "^nut-(.*)?-(.*)": "nutui-uniapp/components/$1$2/$1$2.vue",
-      "^nut-(.*)": "nutui-uniapp/components/$1/$1.vue"
+---
+
+#### 组件导入
+
+::: warning 注意
+自动按需导入组件有 `unplugin` 和 `easycom` 两种方式，请勿混用~
+:::
+
+##### <Badge type="tip">推荐</Badge> unplugin方式
+
+- 安装插件
+
+    > [@uni-helper/vite-plugin-uni-components](https://github.com/uni-helper/vite-plugin-uni-components)
+
+    ::: code-group
+    
+    ```bash [pnpm]
+    pnpm add -D @uni-helper/vite-plugin-uni-components
+    ```
+    
+    ```bash [yarn]
+    yarn add --dev @uni-helper/vite-plugin-uni-components
+    ```
+    
+    ```bash [npm]
+    npm install -D @uni-helper/vite-plugin-uni-components
+    ```
+    
+    :::
+
+- 配置插件
+
+    > vite.config.ts
+
+    ```ts
+    import { defineConfig } from "vite";
+    import UniApp from "@dcloudio/vite-plugin-uni";
+    import Components from "@uni-helper/vite-plugin-uni-components";
+    import { NutResolver } from "nutui-uniapp";
+    
+    // https://vitejs.dev/config
+    export default defineConfig({
+      // ...
+      plugins: [
+        // ...
+        Components({
+          resolvers: [NutResolver()],
+        }),
+        // 注意，UniApp插件一定要放到后面！
+        UniApp()
+      ]
+    });
+    ```
+
+    > 如果使用 `pnpm` 管理依赖，请在项目根目录下的 `.npmrc` 文件中添加如下内容，详细请参考 [issue 389](https://github.com/antfu/unplugin-vue-components/issues/389)
+
+    ```bash
+    shamefully-hoist=true # or public-hoist-pattern[]=@vue*
+    ```
+
+##### easycom方式
+
+- 配置easycom
+
+    > pages.json（若原本已存在easycom字段，则添加easycom.custom字段中的内容）
+
+    ```json5
+    {
+      "easycom": {
+        "autoscan": true,
+        "custom": {
+          "^nut-(.*)?-(.*)": "nutui-uniapp/components/$1$2/$1$2.vue",
+          "^nut-(.*)": "nutui-uniapp/components/$1/$1.vue"
+        }
+      }
+      // ...
     }
-  }
-}
-```
+    ```
 
-### 组件 TS 类型支持
+- 类型提示
 
-想要获取全局组件类型，需要使用 vscode 与[volar 插件](https://cn.vuejs.org/guide/typescript/overview.html#volar-takeover-mode)
+    > tsconfig.json（需要[IDE 支持](https://cn.vuejs.org/guide/typescript/overview.html#ide-support)）
 
-请在 tsconfig.json 中通过 compilerOptions.type 指定全局组件类型。
+    ```json5
+    {
+      "compilerOptions": {
+        // ...
+        "types": ["nutui-uniapp/global.d.ts"]
+      }
+    }
+    ```
 
-```json
-// tsconfig.json
-{
-  "compilerOptions": {
-    // ...
-    "types": ["nutui-uniapp/global.d.ts"]
-  }
-}
-```
+#### 样式引入
 
-<Badge type="tip">推荐</Badge> 或者使用 [@uni-helper/vite-plugin-uni-components](https://github.com/uni-helper/vite-plugin-uni-components) 自动导入组件（注意：此方案与 `easycom` 不能同时使用）
+- 安装sass
 
-```ts
-// vite.config.ts
-import { defineConfig } from 'vite'
-import Components from '@uni-helper/vite-plugin-uni-components'
-import { NutResolver } from 'nutui-uniapp'
+    > nutui-uniapp 依赖 `sass`
 
-// https://vitejs.dev/config/
-export default defineConfig({
-  // ...
-  plugins: [
-    // ...
-    Components({
-      resolvers: [NutResolver()],
-    }),
-    // uni 插件一定要放到后面
-    uni()
-  ],
-})
-```
+    ::: code-group
+    
+    ```bash [pnpm]
+    pnpm add -D sass
+    ```
+    
+    ```bash [yarn]
+    yarn add --dev sass
+    ```
+    
+    ```bash [npm]
+    npm install -D sass
+    ```
+    
+    :::
 
-::: tip
-如果你使用 `pnpm` ，请在根目录下创建一个 `.npmrc` 文件，参见[issue](https://github.com/antfu/unplugin-vue-components/issues/389)。
-:::
+- 全局样式
 
-```bash
-// .npmrc
-public-hoist-pattern[]=@vue*
-// or
-// shamefully-hoist = true
-```
+    > App.vue
 
-see more in [unplugin-vue-components](https://github.com/antfu/unplugin-vue-components#installation)
+    ```html
+    <!-- 注意这里的 lang="scss" -->
+    <style lang="scss">
+      @import "nutui-uniapp/styles/index.scss";
+    
+      // ...
+    </style>
+    ```
 
-### 样式引入
+- 样式变量
 
-<!-- 组件库与 uniapp 都依赖 sass，请先安装 sass -->
+  > 以下两种方式导入样式变量，任选其一即可
 
-在项目文件 `app.vue` 文件中添加如下代码：
+  - uni.scss
 
-```scss
-<style lang="scss">
-@import 'nutui-uniapp/styles/index';
-</style>
-```
+    ```scss
+    @import "nutui-uniapp/styles/variables.scss";
+    ```
 
-导入样式变量
+  - vite.config.ts
 
-```ts
-// vite.config.ts
-import { defineConfig } from 'vite'
+    ```typescript
+    import { defineConfig } from "vite";
+    
+    // https://vitejs.dev/config
+    export default defineConfig({
+      // ...
+      css: {
+        preprocessorOptions: {
+          scss: {
+            additionalData: `@import "nutui-uniapp/styles/variables.scss";`
+          }
+        }
+      }
+    });
+    ```
 
-// https://vitejs.dev/config/
-export default defineConfig({
-  // ...
-  css: {
-    preprocessorOptions: {
-      scss: {
-        additionalData: '@import "nutui-uniapp/styles/variables.scss";',
-      },
-    },
-  },
-})
-```
+### 完成
 
-现在只需使用一个组件，它将按需自动导入。
+---
 
-```html
+> 配置完成，现在所有的组件都可以直接使用，它将自动完成按需导入
+
+```vue
 <template>
-  <nut-button type="primary">
-        主要按钮
-  </nut-button>
+  <nut-button type="primary">主要按钮</nut-button>
+
+  <!-- 或者（仅限unplugin方式） -->
+  <NutButton type="primary">主要按钮</NutButton>
 </template>
 ```
 
-## HBuilderX 导入
+## uni_modules方式
+
+### 下载
+
+---
 
 前往 uniapp 插件市场下载 [nutui-uniapp](https://ext.dcloud.net.cn/plugin?id=13491)
 
 ::: warning
-nutui-uniapp 提供了 npm 包和 uni_modules 包两种方式使用组件。虽然提供了 uni_modules，但是组件库在 hbuilder 中编译存在许多的问题；我们强烈建议使用 vite cli创建项目，它经过了我们测试，还可以使用[uni-helper](https://github.com/uni-helper)团队带来的一系列优秀的库和 vite 生态中的部分插件，你可以通过[官方cli](https://uniapp.dcloud.net.cn/quickstart-cli.html)或是[create-uni](https://github.com/uni-helper/create-uni)创建项目，如果你需要一个功能丰富的起始模板，可以使用我的[uniapp-template](https://github.com/yang1206/uniapp-template)
+nutui-uniapp提供了npm和uni_modules两种方式使用组件。虽然提供了uni_modules，但是组件库在HBuilderX中编译存在许多的问题，所以我们强烈建议使用Vite CLI创建项目，它经过了我们的测试，还可以使用[uni-helper](https://github.com/uni-helper)团队带来的一系列优秀的库和Vite生态中的部分插件，你可以通过[官方CLI](https://uniapp.dcloud.net.cn/quickstart-cli.html)或是[create-uni](https://github.com/uni-helper/create-uni)创建项目，如果你需要一个功能丰富的起始模板，可以使用我们的[uniapp-template](https://github.com/yang1206/uniapp-template)
 :::
-### 按需导入
 
-像下面这样更新 `pages.json` 文件：
+### 配置
 
-```json
-// pages.json
-{
-  "easycom": {
-    "autoscan": true,
-    "custom": {
-      "nut-(.*)?-(.*)": "@/uni_modules/nutui-uni/components/$1$2/$1$2.vue",
-      "nut-(.*)": "@/uni_modules/nutui-uni/components/$1/$1.vue"
-    }
-  }
-}
-```
+---
 
-### 样式引入
+#### 组件导入
 
-<!-- 组件库与 uniapp 都依赖 sass，请先安装 sass -->
+> 与上述npm方式中的[easycom方式](#easycom方式)相同
 
-在项目文件 `app.vue` 文件中添加如下代码：
+#### 样式引入
 
-```scss
-<style lang="scss">
-@import '@/uni_modules/nutui-uni/styles/index.scss';
-</style>
-```
+> 与上述npm方式中的[样式引入](#样式引入)相同，样式变量部分请使用uni.scss方式
 
-导入样式变量
+### 完成
 
-在项目文件 `uni.scss` 文件中添加如下代码：
+---
 
-```scss
-@import '@/uni_modules/nutui-uni/styles/variables.scss';
-```
+> 配置完成，现在所有的组件都可以直接使用，它将自动完成按需导入
 
-然后就可以使用组件了
-
-```html
+```vue
 <template>
-  <nut-button type="primary">
-        主要按钮
-  </nut-button>
+  <nut-button type="primary">主要按钮</nut-button>
 </template>
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@ hero:
 
   actions:
     - theme: brand
-      text: 快速开始
+      text: 快速上手
       link: /guide/overview
 
 features:
@@ -20,7 +20,7 @@ features:
     title: 组件设计
     details: 基于NutUi 4.x，适配了uni-app，使用 Vue 技术栈开发小程序应用，开箱即用，帮助研发快速开发用户界面，提升开发效率，改善开发体验。
     # link: /guide/overview.html
-    # linkText: 快速开始
+    # linkText: 快速上手
   - icon: 🔥
     title: 按需引入
     details: 提供解析器以自动仅导入被使用的组件。

--- a/packages/nutui/README.md
+++ b/packages/nutui/README.md
@@ -45,9 +45,9 @@ nutui-uniapp 组件库，基于Taro版[`NutUi`](https://nutui.jd.com/#/) 4.x版�
 - 🍭 支持暗黑模式
 - 🌍 支持国际化
 
-## 快速开始
+## 快速上手
 
-请参考[快速开始](https://uniapp-nutui.tech/guide/quick-start.html)。
+请参考[快速上手](https://uniapp-nutui.tech/guide/quick-start.html)。
 
 ## 链接
 


### PR DESCRIPTION
重新编写快速上手文档，以避免读者发生混用unplugin和easycom而造成的异常

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **文档更新**
  - 为了更好的清晰度和一致性，更新了文档中的链接标签和文本，从“快速开始”改为“快速上手”。
  - 在`nutui-uniapp`组件库文档中，针对基于`NutUi` 4.x的uni-app开发，更新了链接文本和参考，从“快速开始”改为“快速上手”。
  - 更新了中文文本以增加清晰度。
  - 修订了通过`npm`和`uni_modules`使用`nutui-uniapp`组件的说明。
  - 明确了安装步骤和配置。
  - 提供了关于组件导入方法和样式的指导。
  - 强调了使用Vite CLI创建项目的推荐用法。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->