### PR TITLE
docs: 新增组合式函数自动按需导入配置说明

### DIFF
--- a/docs/components/feedback/toast.md
+++ b/docs/components/feedback/toast.md
@@ -8,144 +8,162 @@
 因为uniapp中无法通过JavaScript代码创建节点，所以组件层面无法实现类似于`uni.showToast`之类的全局调用，若有类似需求可参考[这篇回答](https://github.com/nutui-uniapp/nutui-uniapp/issues/251#issuecomment-2005638878)实现
 :::
 
+### 最简单的用法
+
+> 自 `1.7.5` 开始支持组合式函数用法，`useToast` 的自动按需导入请参考 [快速上手-API导入](/guide/quick-start#api导入) 部分
+
+```typescript
+const toast = useToast();
+
+function showText() {
+  toast.text("文字提示");
+}
+```
+
+```html
+<template>
+  <nut-toast></nut-toast>
+
+  <nut-cell title="Text 文字提示" is-link @click="showText"></nut-cell>
+</template>
+```
+
 ### 组合式函数用法
 
-> 自 `1.7.5` 开始支持组合式函数用法
+```typescript
+import { useToast } from "nutui-uniapp/composables";
 
-```vue
-<script lang="ts" setup>
-  import { useToast } from "nutui-uniapp/composables";
+const toast = useToast();
 
-  const toast = useToast();
+function showText() {
+  toast.text("文字提示");
+}
 
-  function showText() {
-    toast.text("文字提示");
-  }
+function showSuccess() {
+  toast.success("成功提示");
+}
 
-  function showSuccess() {
-    toast.success("成功提示");
-  }
+function showError() {
+  toast.error("错误提示");
+}
 
-  function showError() {
-    toast.error("错误提示");
-  }
+function showWarning() {
+  toast.warning("警告提示");
+}
 
-  function showWarning() {
-    toast.warning("警告提示");
-  }
+function showLoading() {
+  toast.loading("加载提示", {
+    duration: 5000
+  });
+}
 
-  function showLoading() {
-    toast.loading("加载提示", {
-      duration: 5000
-    });
-  }
+function hideLoading() {
+  toast.hide();
+}
+```
 
-  function hideLoading() {
-    toast.hide();
-  }
-</script>
-
+```html
 <template>
-  <nut-toast />
+  <nut-toast></nut-toast>
 
-  <nut-cell title="Text 文字提示" is-link @click="showText" />
-  <nut-cell title="Success 成功提示" is-link @click="showSuccess" />
-  <nut-cell title="Error 错误提示" is-link @click="showError" />
-  <nut-cell title="Warning 警告提示" is-link @click="showWarning" />
-  <nut-cell title="Loading 加载提示" is-link @click="showLoading" />
-  <nut-cell title="手动关闭提示" is-link @click="hideLoading" />
+  <nut-cell title="Text 文字提示" is-link @click="showText"></nut-cell>
+  <nut-cell title="Success 成功提示" is-link @click="showSuccess"></nut-cell>
+  <nut-cell title="Error 错误提示" is-link @click="showError"></nut-cell>
+  <nut-cell title="Warning 警告提示" is-link @click="showWarning"></nut-cell>
+  <nut-cell title="Loading 加载提示" is-link @click="showLoading"></nut-cell>
+  <nut-cell title="手动关闭提示" is-link @click="hideLoading"></nut-cell>
 </template>
 ```
 
 若页面中存在多个`toast`实例，可以使用`selector`改变配置注入的key，以防止同时控制多个实例（注意，`selector`不支持动态修改）
 
-```vue
-<script lang="ts" setup>
-  import { useToast } from "nutui-uniapp/composables";
+```typescript
+const toast = useToast();
+const toast2 = useToast("toast2");
+```
 
-  const toast = useToast();
-  const toast2 = useToast("toast2");
-</script>
-
+```html
 <template>
-  <nut-toast />
-  <nut-toast selector="toast2" />
+  <nut-toast></nut-toast>
+  <nut-toast selector="toast2"></nut-toast>
 </template>
 ```
 
 ### Ref用法
 
-```vue
-<script lang="ts" setup>
-  import type { ToastInst } from "nutui-uniapp";
+```typescript
+import type { ToastInst } from "nutui-uniapp";
 
-  const toast = ref<ToastInst | null>(null);
+const toast = ref<ToastInst | null>(null);
 
-  function showSuccess() {
-    toast.value?.success("成功提示");
-  }
+function showSuccess() {
+  toast.value?.success("成功提示");
+}
 
-  function showError() {
-    toast.value?.error("错误提示");
-  }
+function showError() {
+  toast.value?.error("错误提示");
+}
 
-  function showWarning() {
-    toast.value?.warning("警告提示");
-  }
-</script>
+function showWarning() {
+  toast.value?.warning("警告提示");
+}
+```
 
+```html
 <template>
-  <nut-toast ref="toast" />
+  <nut-toast ref="toast"></nut-toast>
 
-  <nut-cell title="Success 成功提示" is-link @click="showSuccess" />
-  <nut-cell title="Error 错误提示" is-link @click="showError" />
-  <nut-cell title="Warning 警告提示" is-link @click="showWarning" />
+  <nut-cell title="Success 成功提示" is-link @click="showSuccess"></nut-cell>
+  <nut-cell title="Error 错误提示" is-link @click="showError"></nut-cell>
+  <nut-cell title="Warning 警告提示" is-link @click="showWarning"></nut-cell>
 </template>
 ```
 
 ### Props用法
 
-```vue
-<script lang="ts" setup>
-  import type { ToastProps } from "nutui-uniapp";
+```typescript
+import type { ToastProps } from "nutui-uniapp";
 
-  const toastState = ref<Pick<ToastProps, "visible" | "type" | "msg">>({
-    visible: false,
-    type: "text",
-    msg: ""
-  });
+const toastState = ref<Pick<ToastProps, "visible" | "type" | "msg">>({
+  visible: false,
+  type: "text",
+  msg: ""
+});
 
-  function showSuccess() {
-    toastState.value = {
-      visible: true,
-      type: "success",
-      msg: "成功提示"
-    };
-  }
+function showSuccess() {
+  toastState.value = {
+    visible: true,
+    type: "success",
+    msg: "成功提示"
+  };
+}
 
-  function showError() {
-    toastState.value = {
-      visible: true,
-      type: "error",
-      msg: "错误提示"
-    };
-  }
+function showError() {
+  toastState.value = {
+    visible: true,
+    type: "error",
+    msg: "错误提示"
+  };
+}
 
-  function showWarning() {
-    toastState.value = {
-      visible: true,
-      type: "warning",
-      msg: "警告提示"
-    };
-  }
-</script>
+function showWarning() {
+  toastState.value = {
+    visible: true,
+    type: "warning",
+    msg: "警告提示"
+  };
+}
+```
 
+```html
 <template>
-  <nut-toast v-model:visible="toastState.visible" :type="toastState.type" :msg="toastState.msg" />
+  <nut-toast v-model:visible="toastState.visible"
+             :type="toastState.type"
+             :msg="toastState.msg"></nut-toast>
 
-  <nut-cell title="Success 成功提示" is-link @click="showSuccess" />
-  <nut-cell title="Error 错误提示" is-link @click="showError" />
-  <nut-cell title="Warning 警告提示" is-link @click="showWarning" />
+  <nut-cell title="Success 成功提示" is-link @click="showSuccess"></nut-cell>
+  <nut-cell title="Error 错误提示" is-link @click="showError"></nut-cell>
+  <nut-cell title="Warning 警告提示" is-link @click="showWarning"></nut-cell>
 </template>
 ```
 

--- a/docs/guide/quick-start.md
+++ b/docs/guide/quick-start.md
@@ -231,6 +231,7 @@ npm install nutui-uniapp
             "pinia",
             {
               "nutui-uniapp/composables": [
+                // 在这里添加需要自动导入的API
                 "useToast"
               ]
             }

--- a/docs/guide/quick-start.md
+++ b/docs/guide/quick-start.md
@@ -42,29 +42,29 @@ npm install nutui-uniapp
 
 - 安装插件
 
-    > [@uni-helper/vite-plugin-uni-components](https://github.com/uni-helper/vite-plugin-uni-components)
+  > [@uni-helper/vite-plugin-uni-components](https://github.com/uni-helper/vite-plugin-uni-components)
 
-    ::: code-group
-    
+  ::: code-group
+
     ```bash [pnpm]
     pnpm add -D @uni-helper/vite-plugin-uni-components
     ```
-    
+
     ```bash [yarn]
     yarn add --dev @uni-helper/vite-plugin-uni-components
     ```
-    
+
     ```bash [npm]
     npm install -D @uni-helper/vite-plugin-uni-components
     ```
-    
-    :::
+
+  :::
 
 - 配置插件
 
-    > vite.config.ts
+  > vite.config.ts
 
-    ```ts
+    ```typescript
     import { defineConfig } from "vite";
     import UniApp from "@dcloudio/vite-plugin-uni";
     import Components from "@uni-helper/vite-plugin-uni-components";
@@ -84,7 +84,7 @@ npm install nutui-uniapp
     });
     ```
 
-    > 如果使用 `pnpm` 管理依赖，请在项目根目录下的 `.npmrc` 文件中添加如下内容，详细请参考 [issue 389](https://github.com/antfu/unplugin-vue-components/issues/389)
+  > 如果使用 `pnpm` 管理依赖，请在项目根目录下的 `.npmrc` 文件中添加如下内容，详细请参考 [issue 389](https://github.com/antfu/unplugin-vue-components/issues/389)
 
     ```bash
     shamefully-hoist=true # or public-hoist-pattern[]=@vue*
@@ -94,7 +94,7 @@ npm install nutui-uniapp
 
 - 配置easycom
 
-    > pages.json（若原本已存在easycom字段，则添加easycom.custom字段中的内容）
+  > pages.json（若原本已存在easycom字段，则添加easycom.custom字段中的内容）
 
     ```json5
     {
@@ -111,7 +111,7 @@ npm install nutui-uniapp
 
 - 类型提示
 
-    > tsconfig.json（需要[IDE 支持](https://cn.vuejs.org/guide/typescript/overview.html#ide-support)）
+  > tsconfig.json（需要[IDE 支持](https://cn.vuejs.org/guide/typescript/overview.html#ide-support)）
 
     ```json5
     {
@@ -126,27 +126,27 @@ npm install nutui-uniapp
 
 - 安装sass
 
-    > nutui-uniapp 依赖 `sass`
+  > nutui-uniapp 依赖 `sass`
 
-    ::: code-group
-    
+  ::: code-group
+
     ```bash [pnpm]
     pnpm add -D sass
     ```
-    
+
     ```bash [yarn]
     yarn add --dev sass
     ```
-    
+
     ```bash [npm]
     npm install -D sass
     ```
-    
-    :::
+
+  :::
 
 - 全局样式
 
-    > App.vue
+  > App.vue
 
     ```html
     <!-- 注意这里的 lang="scss" -->
@@ -185,13 +185,84 @@ npm install nutui-uniapp
     });
     ```
 
+#### API导入
+
+> 自 `1.7.5` 开始 `nutui-uniapp` 提供了一些组合式函数，可以使用插件配置自动按需导入或者手动导入
+
+##### 自动按需导入
+
+- 安装插件
+
+  > [unplugin-auto-import](https://github.com/unplugin/unplugin-auto-import)
+
+  ::: code-group
+
+    ```bash [pnpm]
+    pnpm add -D unplugin-auto-import
+    ```
+
+    ```bash [yarn]
+    yarn add --dev unplugin-auto-import
+    ```
+
+    ```bash [npm]
+    npm install -D unplugin-auto-import
+    ```
+
+  :::
+
+- 配置插件
+
+  > vite.config.ts
+
+    ```typescript
+    import {defineConfig} from "vite";
+    import AutoImport from "unplugin-auto-import/vite";
+    
+    // https://vitejs.dev/config
+    export default defineConfig({
+      // ...
+      plugins: [
+        // ...
+        AutoImport({
+          imports: [
+            "vue",
+            "uni-app",
+            "pinia",
+            {
+              "nutui-uniapp/composables": [
+                "useToast"
+              ]
+            }
+          ]
+        })
+      ]
+    });
+    ```
+
+- 使用
+
+  ```typescript
+  // 现在无需手动导入即可直接使用
+  const toast = useToast();
+  ```
+
+##### 手动导入
+
+```typescript
+// nutui-uniapp提供的组合式函数都在composables模块下
+import { useToast } from "nutui-uniapp/composables";
+
+const toast = useToast();
+```
+
 ### 完成
 
 ---
 
 > 配置完成，现在所有的组件都可以直接使用，它将自动完成按需导入
 
-```vue
+```html
 <template>
   <nut-button type="primary">主要按钮</nut-button>
 
@@ -224,13 +295,24 @@ nutui-uniapp提供了npm和uni_modules两种方式使用组件。虽然提供了
 
 > 与上述npm方式中的[样式引入](#样式引入)相同，样式变量部分请使用uni.scss方式
 
+#### API导入
+
+> 自 `1.7.5` 开始 `nutui-uniapp` 提供了一些组合式函数
+
+```typescript
+// nutui-uniapp提供的组合式函数都在composables目录下
+import { useToast } from "/uni_modules/nutui-uni/components/composables";
+
+const toast = useToast();
+```
+
 ### 完成
 
 ---
 
 > 配置完成，现在所有的组件都可以直接使用，它将自动完成按需导入
 
-```vue
+```html
 <template>
   <nut-button type="primary">主要按钮</nut-button>
 </template>

--- a/example/src/pages/demo/feedback/toast/index.vue
+++ b/example/src/pages/demo/feedback/toast/index.vue
@@ -1,6 +1,5 @@
 <script lang="ts" setup>
 import type { ToastInst, ToastProps } from 'nutui-uniapp'
-import { useToast } from 'nutui-uniapp/composables'
 
 const toast = useToast()
 

--- a/example/vite.config.ts
+++ b/example/vite.config.ts
@@ -33,7 +33,16 @@ export default defineConfig({
     }),
     UniManifest({ minify: true }),
     AutoImport({
-      imports: ['vue', 'pinia', 'uni-app'],
+      imports: [
+        'vue',
+        'pinia',
+        'uni-app',
+        {
+          'nutui-uniapp/composables': [
+            'useToast'
+          ],
+        }
+      ],
       dts: 'src/auto-imports.d.ts',
       dirs: ['src/composables', 'src/stores'],
       vueTemplate: true,


### PR DESCRIPTION
新增组合式函数自动按需导入配置说明

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 在组件中增加了简单使用toast的新部分。
	- 更新了显示不同类型toast的函数定义。
- **文档**
	- 更新了不同包管理器的安装命令。
	- 调整了`vite.config.ts`中的插件配置。
	- 添加了`pages.json`中`easycom`配置的指令。
	- 更新了IDE支持的TypeScript配置。
	- 提供了为`nutui-uniapp`安装`sass`的指令。
	- 在`App.vue`中进行了全局样式调整。
	- 从`1.7.5`版本开始，介绍了`nutui-uniapp`的API导入，包括自动导入和手动导入的选项。
- **样式**
	- 调整了控制toast可见性和内容的`Props`的使用，增强了使用toast的清晰度和灵活性。
- **重构**
	- 在示例项目中移除了从'nutui-uniapp/composables'导入`useToast`的用法。
	- 在Vite配置文件中，为'nutui-uniapp/composables'的`useToast`添加了新的自动导入配置。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->