### PR TITLE
fix: :bug: 修复Popover 气泡弹出框功能问题

### DIFF
--- a/packages/nutui/components/popover/index.scss
+++ b/packages/nutui/components/popover/index.scss
@@ -245,7 +245,7 @@
   position: fixed;
   top: 0;
   left: 0;
-  z-index: 1999;
+  z-index: 300;
   width: 100%;
   height: 100%;
   background: transparent;

--- a/packages/nutui/components/popover/popover.vue
+++ b/packages/nutui/components/popover/popover.vue
@@ -212,6 +212,8 @@ function closePopover() {
 }
 function chooseItem(item: any, index: number) {
   !item.disabled && emit(CHOOSE_EVENT, item, index)
+}
+function clickContent() {
   if (props.closeOnClickAction)
     closePopover()
 }
@@ -251,13 +253,13 @@ export default defineComponent({
       :duration="+duration" :overlay-style="overlayStyle" :overlay-class="overlayClass"
       :close-on-click-overlay="closeOnClickOverlay"
     >
-      <view :id="popoverContentID" class="nut-popover-content-group">
+      <view :id="popoverContentID" class="nut-popover-content-group" @click.stop="clickContent">
         <view v-if="showArrow" :class="popoverArrow" :style="popoverArrowStyle" />
         <slot name="content" />
         <view
           v-for="(item, index) in list" :key="index"
           class="nut-popover-menu-item" :class="[item.className, item.disabled && 'nut-popover-menu-disabled']"
-          @click.stop="chooseItem(item, index)"
+          @click="chooseItem(item, index)"
         >
           <NutIcon v-if="item.icon" :name="item.icon" custom-class="nut-popover-item-img" />
           <view class="nut-popover-menu-item-name">


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/nutui-uniapp/nutui-uniapp/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Clear and concise description of what the PR is solving. -->

### Linked Issues

<!-- Fix #123. Fix #666. -->

### Additional Context

<!-- Any other context or screenshots about the PR here. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 在弹出层组件中添加了内容点击事件处理功能。
- **样式改动**
	- 调整了弹出层组件的层叠顺序值，从1999修改为300。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->