### PR TITLE
fix(picker): 修复非H5平台mask缺失

### DIFF
--- a/packages/nutui/components/picker/index.scss
+++ b/packages/nutui/components/picker/index.scss
@@ -1,10 +1,16 @@
-@import '../pickercolumn/index';
+@import "../pickercolumn/index";
 
 .nut-theme-dark {
   .nut-picker {
     position: relative;
     background: $dark-background;
     border-radius: 5px;
+
+    /* #ifndef H5 */
+    &__mask {
+      background: none !important;
+    }
+    /* #endif */
 
     // 标题
     &__bar {
@@ -33,13 +39,6 @@
   position: relative;
   background: #fff;
   border-radius: 5px;
-
-  /* #ifndef H5 */
-  &__mask {
-    background: none !important;
-  }
-
-  /* #endif */
 
   // 标题
   &__bar {
@@ -82,7 +81,7 @@
       top: 50%;
       width: 100%;
       height: var(--line-height);
-      content: '';
+      content: "";
       border: $picker-item-active-line-border;
       border-right: 0;
       border-left: 0;


### PR DESCRIPTION
`nut-picker` 修复非H5平台mask缺失

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **样式更新**
	- 在暗黑模式下，更新了选择器组件的遮罩层样式，优化了跨平台的样式兼容性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->