### PR TITLE
feat(calendar): 添加calendar组件点击遮罩关闭事件和点击关闭图标事件

### DIFF
--- a/docs/components/dentry/calendar.md
+++ b/docs/components/dentry/calendar.md
@@ -813,8 +813,8 @@ export default {
 | choose | 选择之后或是点击确认按钮触发,日期数组（包含年月日和星期） | `(string \| string[])[]` |
 | close  | 关闭时触发                   | -                            |
 | select  | 点击/选择后触发              |  `(string \| string[])[]`                          |
-| clickCloseIcon  | 点击关闭图标后触发              |  -                          |
-| clickOverlay  | 点击遮罩关闭后触发              |  -                          |
+| click-close-icon  | 点击关闭图标后触发              |  -                          |
+| click-overlay  | 点击遮罩关闭后触发              |  -                          |
 
 ### Slots
 

--- a/docs/components/dentry/calendar.md
+++ b/docs/components/dentry/calendar.md
@@ -813,6 +813,8 @@ export default {
 | choose | 选择之后或是点击确认按钮触发,日期数组（包含年月日和星期） | `(string \| string[])[]` |
 | close  | 关闭时触发                   | -                            |
 | select  | 点击/选择后触发              |  `(string \| string[])[]`                          |
+| clickCloseIcon  | 点击关闭图标后触发              |  -                          |
+| clickOverlay  | 点击遮罩关闭后触发              |  -                          |
 
 ### Slots
 

--- a/packages/nutui/components/calendar/calendar.ts
+++ b/packages/nutui/components/calendar/calendar.ts
@@ -110,6 +110,8 @@ export const calendarEmits = {
   [CLOSE_EVENT]: () => true,
   [UPDATE_VISIBLE_EVENT]: (val: boolean) => isBoolean(val),
   [SELECT_EVENT]: (val: any) => val,
+  clickCloseIcon: () => true,
+  clickOverlay: () => true,
 }
 
 export type CalendarEmits = typeof calendarEmits

--- a/packages/nutui/components/calendar/calendar.vue
+++ b/packages/nutui/components/calendar/calendar.vue
@@ -77,6 +77,14 @@ function select(param: string) {
   // close();
   emit(SELECT_EVENT, param)
 }
+
+function onClickCloseIcon() {
+  emit('clickCloseIcon')
+}
+
+function onClickOverlay() {
+  emit('clickOverlay')
+}
 </script>
 
 <script lang="ts">
@@ -102,6 +110,8 @@ export default defineComponent({
     :custom-style="{ height: '85vh' }"
     :destroy-on-close="false"
     @opened="opened"
+    @click-close-icon="onClickCloseIcon"
+    @click-overlay="onClickOverlay"
   >
     <NutCalendarItem
       ref="calendarRef"


### PR DESCRIPTION
feature: calendar组件新增点击遮罩关闭事件和点击闭图标事件

# Summary by CodeRabbit
- #### 新功能
  - `calendar`组件添加`clickCloseIcon`事件，点击关闭图标触发
  - `calendar`组件添加`clickOverlay`事件，点击遮罩关闭后触发
- #### 文档
  - 添加`clickCloseIcon`和`clickOverlay`事件描述

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新功能**
    - 在日历组件中新增了两个事件处理功能：当点击关闭图标或覆盖层时，将触发 `clickCloseIcon` 和 `clickOverlay` 事件。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->