### PR TITLE
feat(tag): 新增disbaled、close-icon-size属性

### DIFF
--- a/docs/components/exhibition/tag.md
+++ b/docs/components/exhibition/tag.md
@@ -7,129 +7,92 @@
 ### 基础用法
 
 ```html
-<template>
- <nut-cell-group title="基础用法">
-    <nut-cell title="primary 类型">
-      <template v-slot:link>
-        <nut-tag type="primary">标签</nut-tag>
-      </template>
-    </nut-cell>
-    <nut-cell title="success 类型">
-      <template v-slot:link>
-        <nut-tag type="success">标签</nut-tag>
-      </template>
-    </nut-cell>
-    <nut-cell title="danger 类型">
-      <template v-slot:link>
-        <nut-tag type="danger">标签</nut-tag>
-      </template>
-    </nut-cell>
-    <nut-cell title="warning 类型">
-      <template v-slot:link>
-        <nut-tag type="warning">标签</nut-tag>
-      </template>
-    </nut-cell>
-  </nut-cell-group>
-</template>
+<nut-tag type="primary">标签</nut-tag>
+<nut-tag type="success">标签</nut-tag>
+<nut-tag type="danger">标签</nut-tag>
+<nut-tag type="warning">标签</nut-tag>
 ```
 
 ### 样式风格
 
 ```html
-<template>
-  <nut-cell-group title="样式风格">
-    <nut-cell title="空心样式">
-      <template v-slot:link>
-        <nut-tag plain>标签</nut-tag>
-      </template>
-    </nut-cell>
-    <nut-cell title="圆角样式">
-      <template v-slot:link>
-        <nut-tag round type="primary">标签</nut-tag>
-      </template>
-    </nut-cell>
-    <nut-cell title="标记样式">
-      <template v-slot:link>
-        <nut-tag mark type="primary">标签</nut-tag>
-      </template>
-    </nut-cell>
-    <nut-cell title="可关闭标签">
-      <template v-slot:link>
-        <nut-tag v-if="show" closeable @close="close" type="primary">标签</nut-tag>
-      </template>
-    </nut-cell>
-  </nut-cell-group>
-</template>
+<!-- 空心样式 -->
+<nut-tag plain>标签</nut-tag>
 
-<script lang="ts">
-import { ref } from 'vue';
+<!-- 圆角样式 -->
+<nut-tag type="primary" round>标签</nut-tag>
 
-export default {
-  setup() {
-    const show = ref(true);
-    const close = () => {
-      show.value = false;
-    };
+<!-- 标记样式 -->
+<nut-tag type="primary" mark>标签</nut-tag>
 
-    return {
-      close,
-      show
-    };
-  }
-};
-</script>
+<!-- 可关闭标签 -->
+<nut-tag v-if="show" type="primary" closeable @close="close">标签</nut-tag>
+
+<!-- 关闭图标大小 -->
+<nut-tag type="primary" closeable close-icon-size="8">标签</nut-tag>
+```
+
+```typescript
+const show = ref<boolean>(true);
+
+function close() {
+  show.value = false;
+}
 ```
 
 ### 颜色自定义
 
 ```html
-<template>
-  <nut-cell-group title="颜色自定义">
-    <nut-cell title="背景颜色">
-      <template v-slot:link>
-        <nut-tag custom-color="#FA685D">标签</nut-tag>
-      </template>
-    </nut-cell>
-    <nut-cell title="文字颜色">
-      <template v-slot:link>
-        <nut-tag custom-color="#E9E9E9" textColor="#999999">标签</nut-tag>
-      </template>
-    </nut-cell>
-    <nut-cell title="空心颜色">
-      <template v-slot:link>
-        <nut-tag custom-color="#FA2400" plain>标签</nut-tag>
-      </template>
-    </nut-cell>
-  </nut-cell-group>
-</template>
+<!-- 背景颜色 -->
+<nut-tag custom-color="#fa685d">标签</nut-tag>
+
+<!-- 文字颜色 -->
+<nut-tag custom-color="#e9e9e9" text-color="#999999">标签</nut-tag>
+
+<!-- 空心颜色 -->
+<nut-tag custom-color="#fa2400" plain>标签</nut-tag>
+```
+
+### 禁用状态
+
+> 自 `1.7.7` 开始支持禁用标签，禁用后不会触发 `click` 和 `close` 事件
+
+```html
+<!-- 普通标签 -->
+<nut-tag type="primary" disabled @click="onClick">标签</nut-tag>
+
+<!-- 可关闭标签 -->
+<nut-tag v-if="show" type="primary" closeable disabled @close="close">标签</nut-tag>
 ```
 
 ## API
 
 ### Props
 
-| 参数         | 说明                                                         | 类型    | 默认值    |
-| ------------ | ------------------------------------------------------------ | ------- | --------- |
-| type         | 标签类型，可选值为 `primary`、`success`、`danger`、`warning` | string  | `default` |
-| custom-color | 标签颜色                                                     | string  | `-`       |
-| text-color   | 文本颜色，优先级高于 `color` 属性                            | string  | `white`   |
-| plain        | 是否为空心样式                                               | boolean | `false`   |
-| round        | 是否为圆角样式                                               | boolean | `false`   |
-| mark         | 是否为标记样式                                               | boolean | `false`   |
-| closeable    | 是否为可关闭标签                                             | boolean | `false`   |
+| 参数                      | 说明                                               | 类型              | 默认值     |
+|-------------------------|--------------------------------------------------|-----------------|---------|
+| type                    | 标签类型，可选值为 `primary`、`success`、`danger`、`warning` | string          | default |
+| custom-color            | 标签颜色                                             | string          | -       |
+| text-color              | 文本颜色                                             | string          | -       |
+| plain                   | 是否为空心样式                                          | boolean         | `false` |
+| round                   | 是否为圆角样式                                          | boolean         | `false` |
+| mark                    | 是否为标记样式                                          | boolean         | `false` |
+| closeable               | 是否为可关闭标签                                         | boolean         | `false` |
+| close-icon-size `1.7.7` | 关闭图标大小                                           | number / string | 11px    |
+| disabled `1.7.7`        | 是否禁用                                             | boolean         | `false` |
 
 ### Slots
 
-| 名称    | 说明         |
-| ------- | ------------ |
+| 名称      | 说明     |
+|---------|--------|
 | default | 标签显示内容 |
 
 ### Events
 
-| 事件名 | 说明     | 回调参数 |
-| ------ | -------- | -------- |
-| click  | 点击事件 | `event`  |
-| close  | 关闭事件 | `event`  |
+| 事件名   | 说明   | 回调参数    |
+|-------|------|---------|
+| click | 点击事件 | `event` |
+| close | 关闭事件 | `event` |
 
 ## 主题定制
 
@@ -137,18 +100,20 @@ export default {
 
 组件提供了下列 CSS 变量，可用于自定义样式，使用方法请参考 [ConfigProvider 组件](/components/basic/configprovider)。
 
-| 名称                                    | 默认值                                                                                             |
-| --------------------------------------- | -------------------------------------------------------------------------------------------------- |
-| --nut-tag-font-size                     | 12px                                                                                               |
-| --nut-tag-default-border-radius         | 4px                                                                                                |
-| --nut-tag-round-border-radius           | 8px                                                                                                |
-| --nut-tag-default-background-color      | #000000                                                                                            |
-| --nut-tag-primary-background-color      | #3460fa                                                                                            |
-| --nut-tag-success-background-color      | #4fc08d                                                                                            |
-| --nut-tag-danger-background-color       | linear-gradient(135deg,rgba(242, 20, 12, 1) 0%,rgba(232, 34, 14, 1) 70%,rgba(242, 77, 12, 1) 100%) |
-| --nut-tag-danger-background-color-plain | #df3526                                                                                            |
-| --nut-tag-warning-background-color      | #f3812e                                                                                            |
-| --nut-tag-default-color                 | #ffffff                                                                                            |
-| --nut-tag-border-width                  | 1px                                                                                                |
-| --nut-tag-plain-background-color        | #fff                                                                                               |
-| --nut-tag-height                        | auto                                                                                               |
+| 名称                                          | 默认值                                                                                                |
+|---------------------------------------------|----------------------------------------------------------------------------------------------------|
+| --nut-tag-font-size                         | 12px                                                                                               |
+| --nut-tag-default-border-radius             | 4px                                                                                                |
+| --nut-tag-round-border-radius               | 8px                                                                                                |
+| --nut-tag-default-background-color          | #000000                                                                                            |
+| --nut-tag-primary-background-color          | #3460fa                                                                                            |
+| --nut-tag-success-background-color          | #4fc08d                                                                                            |
+| --nut-tag-danger-background-color           | linear-gradient(135deg,rgba(242, 20, 12, 1) 0%,rgba(232, 34, 14, 1) 70%,rgba(242, 77, 12, 1) 100%) |
+| --nut-tag-danger-background-color-plain     | #df3526                                                                                            |
+| --nut-tag-warning-background-color          | #f3812e                                                                                            |
+| --nut-tag-disabled-background-color `1.7.7` | #ccc                                                                                               |
+| --nut-tag-disabled-close-color `1.7.7`      | #aaa                                                                                               |
+| --nut-tag-default-color                     | #ffffff                                                                                            |
+| --nut-tag-border-width                      | 1px                                                                                                |
+| --nut-tag-plain-background-color            | #fff                                                                                               |
+| --nut-tag-height                            | auto                                                                                               |

--- a/example/src/pages/demo/exhibition/tag/index.vue
+++ b/example/src/pages/demo/exhibition/tag/index.vue
@@ -1,18 +1,8 @@
-<script lang="ts">
-import { ref } from 'vue'
+<script lang="ts" setup>
+const show = ref<boolean>(true)
 
-export default {
-  setup() {
-    const show = ref(true)
-    const close = () => {
-      show.value = false
-    }
-
-    return {
-      close,
-      show,
-    }
-  },
+function close() {
+  show.value = false
 }
 </script>
 
@@ -59,21 +49,28 @@ export default {
       </nut-cell>
       <nut-cell title="圆角样式">
         <template #link>
-          <nut-tag round type="primary">
+          <nut-tag type="primary" round>
             标签
           </nut-tag>
         </template>
       </nut-cell>
       <nut-cell title="标记样式">
         <template #link>
-          <nut-tag mark type="primary">
+          <nut-tag type="primary" mark>
             标签
           </nut-tag>
         </template>
       </nut-cell>
       <nut-cell title="可关闭标签">
         <template #link>
-          <nut-tag v-if="show" closeable type="primary" @close="close">
+          <nut-tag v-if="show" type="primary" closeable @close="close">
+            标签
+          </nut-tag>
+        </template>
+      </nut-cell>
+      <nut-cell title="关闭图标大小">
+        <template #link>
+          <nut-tag type="primary" closeable close-icon-size="8">
             标签
           </nut-tag>
         </template>
@@ -83,21 +80,38 @@ export default {
     <nut-cell-group title="颜色自定义">
       <nut-cell title="背景颜色">
         <template #link>
-          <nut-tag custom-color="#FA685D">
+          <nut-tag custom-color="#fa685d">
             标签
           </nut-tag>
         </template>
       </nut-cell>
       <nut-cell title="文字颜色">
         <template #link>
-          <nut-tag custom-color="#E9E9E9" text-color="#999999">
+          <nut-tag custom-color="#e9e9e9" text-color="#999999">
             标签
           </nut-tag>
         </template>
       </nut-cell>
       <nut-cell title="空心颜色">
         <template #link>
-          <nut-tag custom-color="#FA2400" plain>
+          <nut-tag custom-color="#fa2400" plain>
+            标签
+          </nut-tag>
+        </template>
+      </nut-cell>
+    </nut-cell-group>
+
+    <nut-cell-group title="禁用状态">
+      <nut-cell title="普通标签">
+        <template #link>
+          <nut-tag type="primary" disabled>
+            标签
+          </nut-tag>
+        </template>
+      </nut-cell>
+      <nut-cell title="可关闭标签">
+        <template #link>
+          <nut-tag v-if="show" type="primary" closeable disabled @close="close">
             标签
           </nut-tag>
         </template>
@@ -109,6 +123,7 @@ export default {
 <style lang="scss" scoped>
 .nut-tag {
   margin-right: 15px;
+
   &:last-child {
     margin-bottom: 0;
     margin-right: 0;
@@ -118,11 +133,11 @@ export default {
 .nut-cell {
   align-items: flex-end;
   border-radius: 0;
+
   .nut-cell__title {
     font-size: 13px;
-    font-family: PingFangSC;
     font-weight: 500;
-    color: rgba(102, 102, 102, 1);
+    color: #666;
   }
 }
 </style>

--- a/packages/nutui/components/tag/index.scss
+++ b/packages/nutui/components/tag/index.scss
@@ -88,7 +88,7 @@
     }
 
     .nut-tag--close {
-      opacity: 0.5;
+      color: $tag-disabled-close-color;
     }
   }
 }

--- a/packages/nutui/components/tag/index.scss
+++ b/packages/nutui/components/tag/index.scss
@@ -62,7 +62,7 @@
   }
 
   &--plain {
-    background: #fff !important;
+    background: $white !important;
   }
 
   &--round {
@@ -83,7 +83,7 @@
 
     &.nut-tag--plain {
       color: $tag-disabled-background-color !important;
-      background: #fff !important;
+      background: $white !important;
       border-color: $tag-disabled-background-color !important;
     }
 

--- a/packages/nutui/components/tag/index.scss
+++ b/packages/nutui/components/tag/index.scss
@@ -61,6 +61,10 @@
     }
   }
 
+  &--plain {
+    background: #fff !important;
+  }
+
   &--round {
     border-radius: $tag-round-border-radius;
   }
@@ -72,5 +76,19 @@
   &--close {
     margin-left: 4px;
     cursor: pointer;
+  }
+
+  &--disabled {
+    background: $tag-disabled-background-color !important;
+
+    &.nut-tag--plain {
+      color: $tag-disabled-background-color !important;
+      background: #fff !important;
+      border-color: $tag-disabled-background-color !important;
+    }
+
+    .nut-tag--close {
+      opacity: 0.5;
+    }
   }
 }

--- a/packages/nutui/components/tag/index.ts
+++ b/packages/nutui/components/tag/index.ts
@@ -1,1 +1,2 @@
-export type * from './tag'
+export * from './type'
+export * from './tag'

--- a/packages/nutui/components/tag/tag.ts
+++ b/packages/nutui/components/tag/tag.ts
@@ -1,6 +1,7 @@
 import type { ExtractPropTypes } from 'vue'
-import { commonProps, makeStringProp } from '../_utils'
+import { commonProps, makeNumericProp, makeStringProp } from '../_utils'
 import { CLICK_EVENT, CLOSE_EVENT } from '../_constants'
+import type { TagType } from './type'
 
 export const tagProps = {
   ...commonProps,
@@ -15,7 +16,7 @@ export const tagProps = {
   /**
    * @description 标签类型，可选值为 primary、success、danger、warning
    */
-  type: makeStringProp<'primary' | 'success' | 'danger' | 'warning' | 'default'>('default'),
+  type: makeStringProp<TagType>('default'),
   /**
    * @description 是否为空心样式
    */
@@ -32,14 +33,21 @@ export const tagProps = {
    * @description 是否为可关闭标签
    */
   closeable: Boolean,
+  /**
+   * @description 关闭图表大小
+   */
+  closeIconSize: makeNumericProp(11),
+  /**
+   * @description 是否禁用
+   */
+  disabled: Boolean,
 }
 
 export type TagProps = ExtractPropTypes<typeof tagProps>
 
 export const tagEmits = {
-  [CLICK_EVENT]: (evt: Event) => evt instanceof Object,
-  [CLOSE_EVENT]: (evt: Event) => evt instanceof Object,
-
+  [CLICK_EVENT]: (evt: any) => evt instanceof Object,
+  [CLOSE_EVENT]: (evt: any) => evt instanceof Object,
 }
 
 export type TagEmits = typeof tagEmits

--- a/packages/nutui/components/tag/tag.ts
+++ b/packages/nutui/components/tag/tag.ts
@@ -34,7 +34,7 @@ export const tagProps = {
    */
   closeable: Boolean,
   /**
-   * @description 关闭图表大小
+   * @description 关闭图标大小
    */
   closeIconSize: makeNumericProp(11),
   /**

--- a/packages/nutui/components/tag/tag.vue
+++ b/packages/nutui/components/tag/tag.vue
@@ -16,37 +16,41 @@ const classes = computed(() => {
     [`${componentName}--plain`]: props.plain,
     [`${componentName}--round`]: props.round,
     [`${componentName}--mark`]: props.mark,
+    [`${componentName}--disabled`]: props.disabled,
   })
 })
 
 // 综合考虑 textColor、color、plain 组合使用时的效果
-const style = computed<string>(() => {
-  const style: CSSProperties = {}
+const styles = computed<string>(() => {
+  const value: CSSProperties = {}
+
   // 标签内字体颜色
   if (props.textColor)
-    style.color = props.textColor
-
+    value.color = props.textColor
   else if (props.customColor && props.plain)
-    style.color = props.customColor
+    value.color = props.customColor
 
   // 标签背景与边框颜色
-  if (props.plain) {
-    style.background = '#fff'
-    style['border-color'] = props.customColor
-  }
-  else if (props.customColor) {
-    style.background = props.customColor
-  }
-  return getMainStyle(props, style)
+  if (props.plain)
+    value.borderColor = props.customColor
+  else if (props.customColor)
+    value.background = props.customColor
+
+  return getMainStyle(props, value)
 })
 
-function onClose(event: Event) {
-  event.stopPropagation()
-  emit(CLOSE_EVENT, event)
+function onClick(event: any) {
+  if (props.disabled)
+    return
+
+  emit(CLICK_EVENT, event)
 }
 
-function onClick(event: unknown) {
-  emit(CLICK_EVENT, event as Event)
+function onCloseClick(event: any) {
+  if (props.disabled)
+    return
+
+  emit(CLOSE_EVENT, event)
 }
 </script>
 
@@ -64,12 +68,19 @@ export default defineComponent({
 </script>
 
 <template>
-  <view :class="classes" :style="style" @click="onClick">
+  <view :class="classes" :style="styles" @tap="onClick">
     <slot />
-    <NutIcon v-if="closeable" name="close" custom-class="nut-tag--close" size="11" @click="onClose" />
+
+    <NutIcon
+      v-if="props.closeable"
+      name="close"
+      custom-class="nut-tag--close"
+      :size="props.closeIconSize"
+      @tap.stop="onCloseClick"
+    />
   </view>
 </template>
 
 <style lang="scss">
-@import './index';
+@import "./index";
 </style>

--- a/packages/nutui/components/tag/type.ts
+++ b/packages/nutui/components/tag/type.ts
@@ -1,0 +1,2 @@
+export const tagType = ['primary', 'success', 'danger', 'warning', 'default'] as const
+export type TagType = (typeof tagType)[number]

--- a/packages/nutui/styles/variables.scss
+++ b/packages/nutui/styles/variables.scss
@@ -570,6 +570,7 @@ $tag-danger-background-color: var(
 $tag-danger-background-color-plain: var(--nut-tag-danger-background-color-plain, #df3526) !default;
 $tag-warning-background-color: var(--nut-tag-warning-background-color, #f3812e) !default;
 $tag-disabled-background-color: var(--nut-tag-disabled-background-color, $disable-color) !default;
+$tag-disabled-close-color: var(--nut-tag-disabled-close-color, #aaa) !default;
 $tag-default-color: var(--nut-tag-default-color, #fff) !default;
 $tag-border-width: var(--nut-tag-border-width, 1px) !default;
 $tag-plain-background-color: var(--nut-tag-plain-background-color, #fff) !default;

--- a/packages/nutui/styles/variables.scss
+++ b/packages/nutui/styles/variables.scss
@@ -569,6 +569,7 @@ $tag-danger-background-color: var(
 ) !default;
 $tag-danger-background-color-plain: var(--nut-tag-danger-background-color-plain, #df3526) !default;
 $tag-warning-background-color: var(--nut-tag-warning-background-color, #f3812e) !default;
+$tag-disabled-background-color: var(--nut-tag-disabled-background-color, $disable-color) !default;
 $tag-default-color: var(--nut-tag-default-color, #fff) !default;
 $tag-border-width: var(--nut-tag-border-width, 1px) !default;
 $tag-plain-background-color: var(--nut-tag-plain-background-color, #fff) !default;


### PR DESCRIPTION
`nut-tab` 新增disbaled、close-icon-size属性

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 新增了`close-icon-size`和`disabled`功能。
- **文档**
	- 更新了API文档，提高了清晰度。
- **样式**
	- 添加了`&--plain`和`&--disabled`样式类。
- **重构**
	- `<nut-tag>`组件的使用方式进行了简化。
	- `index.vue`文件使用了Composition API进行重构。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->