### PR TITLE
feat: 完善cell组件 to 属性

### DIFF
--- a/docs/components/basic/cell.md
+++ b/docs/components/basic/cell.md
@@ -169,6 +169,7 @@
 | desc            | 右侧描述                                                                                     | string  | -       |
 | desc-text-align | 右侧描述文本对齐方式 [text-align](https://www.w3school.com.cn/cssref/pr_text_text-align.asp) | string  | `right` |
 | is-link         | 是否展示右侧箭头并开启点击反馈                                                               | boolean | `false` |
+| to        | 跳转地址                                                               | string | - |
 | round-radius    | 圆角半径                                                                                     | number  | `6px`   |
 | center          | 是否使内容垂直居中                                                                           | boolean | `false` |
 | size            | 单元格大小，可选值为 `large`                                                                 | string  | -       |

--- a/docs/components/basic/cell.md
+++ b/docs/components/basic/cell.md
@@ -155,45 +155,45 @@
 
 ### CellGroup Props
 
-| 参数  | 说明     | 类型   | 默认值 |
-| ----- | -------- | ------ | ------ |
-| title | 分组标题 | string | -      |
-| desc  | 分组描述 | string | -      |
+| 参数    | 说明   | 类型     | 默认值 |
+|-------|------|--------|-----|
+| title | 分组标题 | string | -   |
+| desc  | 分组描述 | string | -   |
 
 ### Cell Props
 
-| 参数            | 说明                                                                                         | 类型    | 默认值  |
-| --------------- | -------------------------------------------------------------------------------------------- | ------- | ------- |
-| title           | 标题名称                                                                                     | string  | -       |
-| sub-title       | 左侧副标题                                                                                   | string  | -       |
-| desc            | 右侧描述                                                                                     | string  | -       |
+| 参数              | 说明                                                                                 | 类型      | 默认值     |
+|-----------------|------------------------------------------------------------------------------------|---------|---------|
+| title           | 标题名称                                                                               | string  | -       |
+| sub-title       | 左侧副标题                                                                              | string  | -       |
+| desc            | 右侧描述                                                                               | string  | -       |
 | desc-text-align | 右侧描述文本对齐方式 [text-align](https://www.w3school.com.cn/cssref/pr_text_text-align.asp) | string  | `right` |
-| is-link         | 是否展示右侧箭头并开启点击反馈                                                               | boolean | `false` |
-| to        | 跳转地址                                                               | string | - |
-| round-radius    | 圆角半径                                                                                     | number  | `6px`   |
-| center          | 是否使内容垂直居中                                                                           | boolean | `false` |
+| is-link         | 是否展示右侧箭头并开启点击反馈                                                                    | boolean | `false` |
+| to `1.7.8`      | 跳转地址（uni.navigateTo的url参数）                                                         | string  | -       |
+| round-radius    | 圆角半径                                                                               | number  | `6px`   |
+| center          | 是否使内容垂直居中                                                                          | boolean | `false` |
 | size            | 单元格大小，可选值为 `large`                                                                 | string  | -       |
 
 ### Cell Events
 
-| 事件名 | 说明     | 回调参数      |
-| ------ | -------- | ------------- |
-| click  | 点击事件 | `event:Event` |
+| 事件名   | 说明   | 回调参数          |
+|-------|------|---------------|
+| click | 点击事件 | `event:Event` |
 
 ### Cell Slots
 
-| 名称          | 说明                    |
-| ------------- | ----------------------- |
-| icon          | 自定义左侧 `icon` 区域  |
-| default       | 自定义内容              |
-| link          | 自定义右侧 `link` 区域  |
-| title         | 自定义 `title` 标题区域 |
-| desc `v1.1.6` | 自定义 `desc` 描述区域  |
+| 名称           | 说明               |
+|--------------|------------------|
+| icon         | 自定义左侧 `icon` 区域  |
+| default      | 自定义内容            |
+| link         | 自定义右侧 `link` 区域  |
+| title        | 自定义 `title` 标题区域 |
+| desc `1.1.6` | 自定义 `desc` 描述区域  |
 
 ### CellGroup Slots
 
-| 名称  | 说明                    |
-| ----- | ----------------------- |
+| 名称    | 说明               |
+|-------|------------------|
 | title | 自定义 `title` 标题区域 |
 | desc  | 自定义 `desc` 描述区域  |
 
@@ -203,8 +203,8 @@
 
 组件提供了下列 CSS 变量，可用于自定义样式，使用方法请参考 [ConfigProvider 组件](/components/basic/configprovider)。
 
-| 名称                               | 默认值                                 |
-| ---------------------------------- | -------------------------------------- |
+| 名称                                 | 默认值                                    |
+|------------------------------------|----------------------------------------|
 | --nut-cell-color                   | var(--nut-title-color2)                |
 | --nut-cell-title-font              | var(--nut-font-size-2)                 |
 | --nut-cell-title-desc-font         | var(--nut-font-size-1)                 |

--- a/example/src/auto-imports.d.ts
+++ b/example/src/auto-imports.d.ts
@@ -89,6 +89,7 @@ declare global {
   const useCssModule: typeof import('vue')['useCssModule']
   const useCssVars: typeof import('vue')['useCssVars']
   const useSlots: typeof import('vue')['useSlots']
+  const useToast: typeof import('nutui-uniapp/composables')['useToast']
   const watch: typeof import('vue')['watch']
   const watchEffect: typeof import('vue')['watchEffect']
   const watchPostEffect: typeof import('vue')['watchPostEffect']
@@ -188,6 +189,7 @@ declare module 'vue' {
     readonly useCssModule: UnwrapRef<typeof import('vue')['useCssModule']>
     readonly useCssVars: UnwrapRef<typeof import('vue')['useCssVars']>
     readonly useSlots: UnwrapRef<typeof import('vue')['useSlots']>
+    readonly useToast: UnwrapRef<typeof import('nutui-uniapp/composables')['useToast']>
     readonly watch: UnwrapRef<typeof import('vue')['watch']>
     readonly watchEffect: UnwrapRef<typeof import('vue')['watchEffect']>
     readonly watchPostEffect: UnwrapRef<typeof import('vue')['watchPostEffect']>
@@ -280,6 +282,7 @@ declare module '@vue/runtime-core' {
     readonly useCssModule: UnwrapRef<typeof import('vue')['useCssModule']>
     readonly useCssVars: UnwrapRef<typeof import('vue')['useCssVars']>
     readonly useSlots: UnwrapRef<typeof import('vue')['useSlots']>
+    readonly useToast: UnwrapRef<typeof import('nutui-uniapp/composables')['useToast']>
     readonly watch: UnwrapRef<typeof import('vue')['watch']>
     readonly watchEffect: UnwrapRef<typeof import('vue')['watchEffect']>
     readonly watchPostEffect: UnwrapRef<typeof import('vue')['watchPostEffect']>

--- a/packages/nutui/components/cell/cell.vue
+++ b/packages/nutui/components/cell/cell.vue
@@ -6,7 +6,8 @@ import Icon from '../icon/icon.vue'
 import { cellEmits, cellProps } from './cell'
 
 const props = defineProps(cellProps)
-const emits = defineEmits(cellEmits)
+
+const emit = defineEmits(cellEmits)
 
 const classes = computed(() => {
   return getMainClass(props, componentName, {
@@ -16,18 +17,20 @@ const classes = computed(() => {
   })
 })
 
-const getStyle = computed(() => {
+const styles = computed(() => {
   return getMainStyle(props, {
     borderRadius: pxCheck(props.roundRadius),
   })
 })
 
-function handleClick(event: Event) {
-  const url = props.to
-  if (props.isLink)
-    emits(CLICK_EVENT, event)
-  if (url && props.isLink)
-    uni.navigateTo({ url })
+function handleClick(event: any) {
+  emit(CLICK_EVENT, event)
+
+  if (props.to) {
+    uni.navigateTo({
+      url: props.to,
+    })
+  }
 }
 </script>
 
@@ -47,44 +50,50 @@ export default defineComponent({
 </script>
 
 <template>
-  <view :class="classes" :style="getStyle" @click="(handleClick as any)">
+  <view :class="classes" :style="styles" @click="handleClick">
     <slot>
       <view v-if="$slots.icon" class="nut-cell__icon">
         <slot name="icon" />
       </view>
-      <view v-if="title || subTitle || $slots.title" class="nut-cell__title">
-        <template v-if="subTitle">
+
+      <view v-if="props.title || props.subTitle || $slots.title" class="nut-cell__title">
+        <template v-if="props.subTitle">
           <slot name="title">
             <view class="title">
-              {{ title }}
+              {{ props.title }}
             </view>
           </slot>
+
           <view class="nut-cell__title-desc">
-            {{ subTitle }}
+            {{ props.subTitle }}
           </view>
         </template>
+
         <template v-else>
           <slot name="title">
-            {{ title }}
+            {{ props.title }}
           </slot>
         </template>
       </view>
+
       <view
-        v-if="desc || $slots.desc" class="nut-cell__value"
-        :class="{ 'nut-cell__value--alone': (!title && !subTitle && !$slots.title) }"
-        :style="{ 'text-align': descTextAlign }"
+        v-if="props.desc || $slots.desc"
+        class="nut-cell__value"
+        :class="{ 'nut-cell__value--alone': !props.title && !props.subTitle && !$slots.title }"
+        :style="{ 'text-align': props.descTextAlign }"
       >
         <slot name="desc">
-          {{ desc }}
+          {{ props.desc }}
         </slot>
       </view>
+
       <slot name="link">
-        <Icon v-if="isLink || to" name="right" class="nut-cell__link" />
+        <Icon v-if="props.isLink || props.to" custom-class="nut-cell__link" name="right" />
       </slot>
     </slot>
   </view>
 </template>
 
 <style lang="scss">
-@import './index';
+@import "./index";
 </style>

--- a/packages/nutui/components/cell/cell.vue
+++ b/packages/nutui/components/cell/cell.vue
@@ -23,7 +23,11 @@ const getStyle = computed(() => {
 })
 
 function handleClick(event: Event) {
-  emits(CLICK_EVENT, event)
+  const url = props.to
+  if (props.isLink)
+    emits(CLICK_EVENT, event)
+  if (url && props.isLink)
+    uni.navigateTo({ url })
 }
 </script>
 


### PR DESCRIPTION
完成 cell 组件 to 属性

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新功能**
    - 在单元组件中添加了一个新属性 `to`，用于指定跳转地址。
    - 新增了一个 `useToast` 导出实体，用于增强 Vue 相关模块的功能。
    - 在 `cell.vue` 文件中修改了 `handleClick` 函数，根据 `isLink` 属性条件性地触发 `CLICK_EVENT` 事件，并在存在 `isLink` 和 `url` 属性时导航到URL。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->