### PR TITLE
refactor(tag): 重构标签样式实现

### DIFF
--- a/docs/components/exhibition/tag.md
+++ b/docs/components/exhibition/tag.md
@@ -100,20 +100,21 @@ function close() {
 
 组件提供了下列 CSS 变量，可用于自定义样式，使用方法请参考 [ConfigProvider 组件](/components/basic/configprovider)。
 
-| 名称                                          | 默认值                                                                                                |
-|---------------------------------------------|----------------------------------------------------------------------------------------------------|
-| --nut-tag-font-size                         | 12px                                                                                               |
-| --nut-tag-default-border-radius             | 4px                                                                                                |
-| --nut-tag-round-border-radius               | 8px                                                                                                |
-| --nut-tag-default-background-color          | #000000                                                                                            |
-| --nut-tag-primary-background-color          | #3460fa                                                                                            |
-| --nut-tag-success-background-color          | #4fc08d                                                                                            |
-| --nut-tag-danger-background-color           | linear-gradient(135deg,rgba(242, 20, 12, 1) 0%,rgba(232, 34, 14, 1) 70%,rgba(242, 77, 12, 1) 100%) |
-| --nut-tag-danger-background-color-plain     | #df3526                                                                                            |
-| --nut-tag-warning-background-color          | #f3812e                                                                                            |
-| --nut-tag-disabled-background-color `1.7.7` | #ccc                                                                                               |
-| --nut-tag-disabled-close-color `1.7.7`      | #aaa                                                                                               |
-| --nut-tag-default-color                     | #ffffff                                                                                            |
-| --nut-tag-border-width                      | 1px                                                                                                |
-| --nut-tag-plain-background-color            | #fff                                                                                               |
-| --nut-tag-height                            | auto                                                                                               |
+| 名称                                          | 默认值           |
+|---------------------------------------------|---------------|
+| --nut-tag-height                            | auto          |
+| --nut-tag-padding `1.7.8`                   | 0 4px         |
+| --nut-tag-font-size                         | 12px          |
+| --nut-tag-default-color                     | #fff          |
+| --nut-tag-border-width                      | 1px           |
+| --nut-tag-default-border-radius             | 4px           |
+| --nut-tag-round-border-radius               | 8px           |
+| --nut-tag-mark-border-radius                | 0 12px 12px 0 |
+| --nut-tag-default-background-color          | #000          |
+| --nut-tag-primary-background-color          | #3460fa       |
+| --nut-tag-success-background-color          | #4fc08d       |
+| --nut-tag-danger-background-color           | #df3526       |
+| --nut-tag-warning-background-color          | #f3812e       |
+| --nut-tag-plain-background-color            | transparent   |
+| --nut-tag-disabled-background-color `1.7.7` | #ccc          |
+| --nut-tag-disabled-close-color `1.7.7`      | #aaa          |

--- a/packages/nutui/components/tag/index.scss
+++ b/packages/nutui/components/tag/index.scss
@@ -4,62 +4,58 @@
   height: $tag-height;
   padding: $tag-padding;
   font-size: $tag-font-size;
+  color: $tag-default-color;
   border-style: solid;
   border-width: $tag-border-width;
   border-radius: $tag-default-border-radius;
 
   &--default {
-    color: $tag-default-color;
     background: $tag-default-background-color;
     border-color: $tag-default-background-color;
 
     &.nut-tag--plain {
       color: $tag-default-background-color;
-      background: transparent;
+      background: $tag-plain-background-color;
     }
   }
 
   &--primary {
-    color: $tag-default-color;
     background: $tag-primary-background-color;
     border-color: $tag-primary-background-color;
 
     &.nut-tag--plain {
       color: $tag-primary-background-color;
-      background: transparent;
+      background: $tag-plain-background-color;
     }
   }
 
   &--success {
-    color: $tag-default-color;
     background: $tag-success-background-color;
     border-color: $tag-success-background-color;
 
     &.nut-tag--plain {
       color: $tag-success-background-color;
-      background: transparent;
+      background: $tag-plain-background-color;
     }
   }
 
   &--danger {
-    color: $tag-default-color;
     background: $tag-danger-background-color;
     border-color: $tag-danger-background-color;
 
     &.nut-tag--plain {
       color: $tag-danger-background-color;
-      background: transparent;
+      background: $tag-plain-background-color;
     }
   }
 
   &--warning {
-    color: $tag-default-color;
     background: $tag-warning-background-color;
     border-color: $tag-warning-background-color;
 
     &.nut-tag--plain {
       color: $tag-warning-background-color;
-      background: transparent;
+      background: $tag-plain-background-color;
     }
   }
 
@@ -82,7 +78,7 @@
 
     &.nut-tag--plain {
       color: $tag-disabled-background-color !important;
-      background: transparent !important;
+      background: $tag-plain-background-color !important;
       border-color: $tag-disabled-background-color !important;
     }
 

--- a/packages/nutui/components/tag/index.scss
+++ b/packages/nutui/components/tag/index.scss
@@ -2,67 +2,65 @@
   display: inline-flex;
   align-items: center;
   height: $tag-height;
-  padding: 0 4px;
+  padding: $tag-padding;
   font-size: $tag-font-size;
+  border-style: solid;
+  border-width: $tag-border-width;
   border-radius: $tag-default-border-radius;
 
   &--default {
     color: $tag-default-color;
     background: $tag-default-background-color;
-    border: $tag-border-width solid transparent;
+    border-color: $tag-default-background-color;
 
     &.nut-tag--plain {
       color: $tag-default-background-color;
-      border: $tag-border-width solid $tag-default-background-color;
+      background: transparent;
     }
   }
 
   &--primary {
     color: $tag-default-color;
     background: $tag-primary-background-color;
-    border: $tag-border-width solid transparent;
+    border-color: $tag-primary-background-color;
 
     &.nut-tag--plain {
       color: $tag-primary-background-color;
-      border: $tag-border-width solid $tag-primary-background-color;
+      background: transparent;
     }
   }
 
   &--success {
     color: $tag-default-color;
     background: $tag-success-background-color;
-    border: $tag-border-width solid transparent;
+    border-color: $tag-success-background-color;
 
     &.nut-tag--plain {
       color: $tag-success-background-color;
-      border: $tag-border-width solid $tag-success-background-color;
+      background: transparent;
     }
   }
 
   &--danger {
     color: $tag-default-color;
     background: $tag-danger-background-color;
-    border: $tag-border-width solid transparent;
+    border-color: $tag-danger-background-color;
 
     &.nut-tag--plain {
-      color: $tag-danger-background-color-plain;
-      border: $tag-border-width solid $tag-danger-background-color-plain;
+      color: $tag-danger-background-color;
+      background: transparent;
     }
   }
 
   &--warning {
     color: $tag-default-color;
     background: $tag-warning-background-color;
-    border: $tag-border-width solid transparent;
+    border-color: $tag-warning-background-color;
 
     &.nut-tag--plain {
       color: $tag-warning-background-color;
-      border: $tag-border-width solid $tag-warning-background-color;
+      background: transparent;
     }
-  }
-
-  &--plain {
-    background: $white !important;
   }
 
   &--round {
@@ -70,7 +68,7 @@
   }
 
   &--mark {
-    border-radius: 0 12px 12px 0;
+    border-radius: $tag-mark-border-radius;
   }
 
   &--close {
@@ -80,10 +78,11 @@
 
   &--disabled {
     background: $tag-disabled-background-color !important;
+    border-color: $tag-disabled-background-color !important;
 
     &.nut-tag--plain {
       color: $tag-disabled-background-color !important;
-      background: $white !important;
+      background: transparent !important;
       border-color: $tag-disabled-background-color !important;
     }
 

--- a/packages/nutui/components/tag/tag.vue
+++ b/packages/nutui/components/tag/tag.vue
@@ -20,21 +20,23 @@ const classes = computed(() => {
   })
 })
 
-// 综合考虑 textColor、color、plain 组合使用时的效果
 const styles = computed<string>(() => {
   const value: CSSProperties = {}
 
-  // 标签内字体颜色
   if (props.textColor)
     value.color = props.textColor
-  else if (props.customColor && props.plain)
-    value.color = props.customColor
 
-  // 标签背景与边框颜色
-  if (props.plain)
+  if (props.customColor) {
     value.borderColor = props.customColor
-  else if (props.customColor)
-    value.background = props.customColor
+
+    if (props.plain) {
+      if (!props.textColor)
+        value.color = props.customColor
+    }
+    else {
+      value.background = props.customColor
+    }
+  }
 
   return getMainStyle(props, value)
 })

--- a/packages/nutui/styles/variables.scss
+++ b/packages/nutui/styles/variables.scss
@@ -558,16 +558,14 @@ $timeselect-timedetail-item-cur-text-color: var(
 
 //  tag
 $tag-font-size: var(--nut-tag-font-size, 12px) !default;
+$tag-padding: var(--nut-tag-padding, 0 4px) !default;
 $tag-default-border-radius: var(--nut-tag-default-border-radius, 4px) !default;
 $tag-round-border-radius: var(--nut-tag-round-border-radius, 8px) !default;
+$tag-mark-border-radius: var(--nut-tag-mark-border-radius, 0 12px 12px 0) !default;
 $tag-default-background-color: var(--nut-tag-default-background-color, #000) !default;
 $tag-primary-background-color: var(--nut-tag-primary-background-color, #3460fa) !default;
 $tag-success-background-color: var(--nut-tag-success-background-color, #4fc08d) !default;
-$tag-danger-background-color: var(
-  --nut-tag-danger-background-color,
-  linear-gradient(135deg, rgb(242 20 12 / 100%) 0%, rgb(232 34 14 / 100%) 70%, rgb(242 77 12 / 100%) 100%)
-) !default;
-$tag-danger-background-color-plain: var(--nut-tag-danger-background-color-plain, #df3526) !default;
+$tag-danger-background-color: var(--nut-tag-danger-background-color, #df3526) !default;
 $tag-warning-background-color: var(--nut-tag-warning-background-color, #f3812e) !default;
 $tag-disabled-background-color: var(--nut-tag-disabled-background-color, $disable-color) !default;
 $tag-disabled-close-color: var(--nut-tag-disabled-close-color, #aaa) !default;

--- a/packages/nutui/styles/variables.scss
+++ b/packages/nutui/styles/variables.scss
@@ -557,8 +557,11 @@ $timeselect-timedetail-item-cur-text-color: var(
 ) !default;
 
 //  tag
-$tag-font-size: var(--nut-tag-font-size, 12px) !default;
+$tag-height: var(--nut-tag-height, auto) !default;
 $tag-padding: var(--nut-tag-padding, 0 4px) !default;
+$tag-font-size: var(--nut-tag-font-size, 12px) !default;
+$tag-default-color: var(--nut-tag-default-color, #fff) !default;
+$tag-border-width: var(--nut-tag-border-width, 1px) !default;
 $tag-default-border-radius: var(--nut-tag-default-border-radius, 4px) !default;
 $tag-round-border-radius: var(--nut-tag-round-border-radius, 8px) !default;
 $tag-mark-border-radius: var(--nut-tag-mark-border-radius, 0 12px 12px 0) !default;
@@ -567,12 +570,9 @@ $tag-primary-background-color: var(--nut-tag-primary-background-color, #3460fa) 
 $tag-success-background-color: var(--nut-tag-success-background-color, #4fc08d) !default;
 $tag-danger-background-color: var(--nut-tag-danger-background-color, #df3526) !default;
 $tag-warning-background-color: var(--nut-tag-warning-background-color, #f3812e) !default;
+$tag-plain-background-color: var(--nut-tag-plain-background-color, transparent) !default;
 $tag-disabled-background-color: var(--nut-tag-disabled-background-color, $disable-color) !default;
 $tag-disabled-close-color: var(--nut-tag-disabled-close-color, #aaa) !default;
-$tag-default-color: var(--nut-tag-default-color, #fff) !default;
-$tag-border-width: var(--nut-tag-border-width, 1px) !default;
-$tag-plain-background-color: var(--nut-tag-plain-background-color, #fff) !default;
-$tag-height: var(--nut-tag-height, auto) !default;
 
 //  badge
 $badge-background-color: var(


### PR DESCRIPTION
`nut-tag` 重构标签样式实现

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **样式更新**
	- 更新了标签组件的样式，包括高度、内边距、字体大小、颜色、边框圆角和不同状态下的背景颜色。
	- 优化了默认、主要、成功、危险和警告等不同标签变体的样式设置。
	- 改进了自定义颜色和纯样式标签的颜色分配逻辑。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->