### PR TITLE
fix: 修改tabs选项卡微笑曲线属性，在navbar组件content slot中样式出错bug

### DIFF
--- a/packages/nutui/components/tabs/index.scss
+++ b/packages/nutui/components/tabs/index.scss
@@ -64,6 +64,7 @@
       &__smile {
         .nut-icon {
           position: absolute;
+          left: 0;
           width: 100%;
           height: 100%;
           font-size: 12px;


### PR DESCRIPTION
### 修改之前
![image](https://github.com/nutui-uniapp/nutui-uniapp/assets/39794167/ccd78e45-9d47-479e-b039-e50684c8e7a1)
![image](https://github.com/nutui-uniapp/nutui-uniapp/assets/39794167/245ecfab-6384-47c8-95cc-9b73d896f1df)



### 修改之后
![image](https://github.com/nutui-uniapp/nutui-uniapp/assets/39794167/cc270c0b-703c-4817-a451-a398ee00830f)
![image](https://github.com/nutui-uniapp/nutui-uniapp/assets/39794167/96c16c15-2301-4b58-bd55-be657c669072)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **样式更新**
	- 更新了标签页图标的位置，确保其正确对齐。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->