### PR TITLE
修复 在Android14微信小程序中，input focus后点击清除，值实际未清除的问题

### DIFF
--- a/packages/nutui/components/input/input.vue
+++ b/packages/nutui/components/input/input.vue
@@ -219,7 +219,7 @@ export default defineComponent({
         :hold-keyboard="props.holdKeyboard"
         @input="handleInput"
         @focus="handleFocus"
-        @blur="handleBlur"
+        @blur.capture="handleBlur"
         @click="handleClickInput"
         @change="endComposing"
         @compositionstart="startComposing"


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/nutui-uniapp/nutui-uniapp/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

ui版本：1.7.10
机型：小米mix4（hyper os 1.0.2.0.UKMCNXM）Android14
微信版本：8.0.49

在微信开发者工具上结果是正确的。

在手机上点击清除图标，实测先触发clear，再触发blur，再触发update:modelValue，这时会把blur中得到的值传给update:modelValue，导致需要点很多次才能清除

解决方式：捕获blur，优先触发blur再触发clear
