### PR TITLE
使用innerValue.value的值代替blur事件返回的值

### DIFF
--- a/packages/nutui/components/input/input.vue
+++ b/packages/nutui/components/input/input.vue
@@ -219,7 +219,7 @@ export default defineComponent({
         :hold-keyboard="props.holdKeyboard"
         @input="handleInput"
         @focus="handleFocus"
-        @blur="handleBlur"
+        @blur.capture="handleBlur"
         @click="handleClickInput"
         @change="endComposing"
         @compositionstart="startComposing"

--- a/packages/nutui/components/input/input.vue
+++ b/packages/nutui/components/input/input.vue
@@ -120,7 +120,7 @@ function handleBlur(evt: InputOnBlurEvent) {
     active.value = false
   }, 200)
 
-  updateValue(evt.detail.value, 'onBlur')
+  updateValue(innerValue.value, 'onBlur')
 
   emit(BLUR_EVENT, evt)
 }
@@ -219,7 +219,7 @@ export default defineComponent({
         :hold-keyboard="props.holdKeyboard"
         @input="handleInput"
         @focus="handleFocus"
-        @blur.capture="handleBlur"
+        @blur="handleBlur"
         @click="handleClickInput"
         @change="endComposing"
         @compositionstart="startComposing"


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/nutui-uniapp/nutui-uniapp/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

使用innerValue.value的值代替blur事件返回的值

### Linked Issues

<!-- Fix #123. Fix #666. -->
关联：https://github.com/nutui-uniapp/nutui-uniapp/issues/309

### Additional Context

<!-- Any other context or screenshots about the PR here. -->