### PR TITLE
fix(navbar): 修复 navbar safe-area-inset-top 不生效的问题

### DIFF
--- a/packages/nutui/components/navbar/index.scss
+++ b/packages/nutui/components/navbar/index.scss
@@ -24,61 +24,31 @@
   background: $navbar-background;
   box-shadow: $navbar-box-shadow;
 
-  &:active::before {
-    opacity: 0.1;
-  }
+  $block: &;
 
-  &--border {
+  &#{$block}--border {
     border-bottom: 1px solid #eee;
   }
 
-  &--fixed {
+  &#{$block}--fixed {
     position: fixed;
     top: 0;
     left: 0;
     width: 100%;
-
-    &.nut-navbar--safe-area-inset-top {
-      // height: calc($navbar-height + constant(safe-area-inset-top));
-      // height: calc($navbar-height + var(--status-bar-height));
-      height: calc($navbar-height + env(safe-area-inset-top));
-    }
   }
 
-  &--placeholder {
+  &#{$block}--placeholder {
     display: block;
     width: 100%;
   }
 
-  &--safe-area-inset-top {
-    // padding-top: constant(safe-area-inset-top);
-    // padding-top: var(--status-bar-height);
+  &#{$block}--safe-area-inset-top {
+    height: calc($navbar-height + var(--status-bar-height));
+    height: calc($navbar-height + constant(safe-area-inset-top));
+    height: calc($navbar-height + env(safe-area-inset-top));
+    padding-top: var(--status-bar-height);
+    padding-top: constant(safe-area-inset-top);
     padding-top: env(safe-area-inset-top);
-  }
-
-
-
-  &--clickable {
-    &::before {
-      position: absolute;
-      top: 50%;
-      left: 50%;
-      width: 100%;
-      height: 100%;
-      content: ' ';
-      background-color: $black;
-      border: inherit;
-      border-color: $black;
-      border-radius: inherit;
-      opacity: 0;
-      transform: translate(-50%, -50%);
-    }
-  }
-
-  :deep(.nutui-iconfont) {
-    .nut-icon-left {
-      text-align: left;
-    }
   }
 
   &__title {
@@ -101,60 +71,49 @@
       -webkit-line-clamp: 1;
     }
 
-    &.icon {
-      .icon {
-        margin: $navbar-title-icon-margin;
-      }
-    }
-
     .icon {
-      font-size: 0;
+      margin: $navbar-title-icon-margin;
     }
 
     :deep(.nut-icon) {
-      display: inline;
-    }
-
-    &-desc {
-      font-size: $cell-title-desc-font;
-    }
-
-    .text__title {
-      display: inline-block;
+      display: inline !important;
     }
 
     :deep(.nut-tabs__titles) {
-      background: $white;
+      background: transparent !important;
     }
 
     :deep(.nut-tab-pane) {
+      display: none !important;
+    }
+
+    ::-webkit-scrollbar {
       display: none;
     }
   }
 
-  &__title ::-webkit-scrollbar {
-    display: none;
+  &__left,
+  &__right {
+    position: absolute;
+    display: flex;
+    align-items: center;
+    padding: 0 16px;
+    font-size: $cell-desc-font;
+    color: $cell-desc-color;
+    cursor: pointer;
   }
 
   &__left {
-    position: absolute;
     left: 0;
-    display: flex;
-    align-items: center;
-    padding: 0 16px;
-    font-size: $cell-desc-font;
-    color: $cell-desc-color;
-    cursor: pointer;
+
+    :deep(.nut-icon) {
+      &.nut-icon-left {
+        text-align: left !important;
+      }
+    }
   }
 
   &__right {
-    position: absolute;
     right: 0;
-    display: flex;
-    align-items: center;
-    padding: 0 16px;
-    font-size: $cell-desc-font;
-    color: $cell-desc-color;
-    cursor: pointer;
   }
 }

--- a/packages/nutui/components/navbar/index.scss
+++ b/packages/nutui/components/navbar/index.scss
@@ -39,8 +39,9 @@
     width: 100%;
 
     &.nut-navbar--safe-area-inset-top {
-      height: calc($navbar-height + constant(safe-area-inset-top));
-      height: calc($navbar-height + var(--status-bar-height));
+      // height: calc($navbar-height + constant(safe-area-inset-top));
+      // height: calc($navbar-height + var(--status-bar-height));
+      height: calc($navbar-height + env(safe-area-inset-top));
     }
   }
 
@@ -50,8 +51,9 @@
   }
 
   &--safe-area-inset-top {
-    padding-top: constant(safe-area-inset-top);
-    padding-top: var(--status-bar-height);
+    // padding-top: constant(safe-area-inset-top);
+    // padding-top: var(--status-bar-height);
+    padding-top: env(safe-area-inset-top);
   }
 
 


### PR DESCRIPTION
### Description

1、微信小程序只支持 env，参考 https://developers.weixin.qq.com/miniprogram/dev/framework/runtime/skyline/wxss.html#%E7%B1%BB%E5%9E%8B%E6%94%AF%E6%8C%81%E5%88%97%E8%A1%A8。

2、--status-bar-height 在小程序固定为 25px，在 IOS 下使用 navbar safe-area-inset-top  时无法填满整个状态栏： iPhone X/XR/XS Max 状态栏高度为 44px，12/13 mini/pro/pro max 状态栏高度为 47px，14/15 pro max状态栏高度为54px。故注释此样式。 参考 https://uniapp.dcloud.net.cn/tutorial/syntax-css.html#css-%E5%8F%98%E9%87%8F。
