### PR TITLE
适配2021年前的旧机型

### DIFF
--- a/packages/nutui/components/numberkeyboard/index.scss
+++ b/packages/nutui/components/numberkeyboard/index.scss
@@ -1,17 +1,15 @@
-@import '../popup/index';
+@import "../popup/index";
 
 .nut-theme-dark {
   .nut-number-keyboard {
     background-color: $dark-background4;
 
-    .nut-key__wrapper{
+    .nut-key__wrapper {
       .nut-key {
         color: $dark-color;
         background-color: $dark-background5;
       }
     }
-    
-    
   }
 }
 
@@ -65,27 +63,7 @@
       flex-direction: column;
 
       .nut-key__wrapper {
-        margin: 0 6px 6px 0;
-
         .nut-key {
-          position: absolute;
-
-          /* #ifndef APP-PLUS */
-          
-          // inset: 0 6px 6px 0;
-
-          /* #endif */
-
-          /* #ifdef APP-PLUS */
-
-          /* stylelint-disable declaration-block-no-redundant-longhand-properties */
-          // top: 0;
-          // right: 6px;
-          // bottom: 6px;
-          // left:0;
-
-          /* #endif */
-
           width: 100%;
           height: 100%;
         }

--- a/packages/nutui/components/numberkeyboard/index.scss
+++ b/packages/nutui/components/numberkeyboard/index.scss
@@ -65,26 +65,29 @@
       flex-direction: column;
 
       .nut-key__wrapper {
+        margin: 0 6px 6px 0;
+
         .nut-key {
           position: absolute;
 
           /* #ifndef APP-PLUS */
           
-          inset: 0 6px 6px 0;
+          // inset: 0 6px 6px 0;
 
           /* #endif */
 
           /* #ifdef APP-PLUS */
 
           /* stylelint-disable declaration-block-no-redundant-longhand-properties */
-          top: 0;
-          right: 6px;
-          bottom: 6px;
-          left:0;
+          // top: 0;
+          // right: 6px;
+          // bottom: 6px;
+          // left:0;
 
           /* #endif */
-          
-          height: auto;
+
+          width: 100%;
+          height: 100%;
         }
 
         .nut-key--finish {


### PR DESCRIPTION
部分机型对 Inset 不支持，当 number-key-board 在带有右侧删除按钮和完成按钮时无法铺满，此次修改主要是提升兼容性。
