### PR TITLE
fix(picker): 修复showToolbar等于false时,picker组件宽度为0不显示的问题

### DIFF
--- a/packages/nutui/components/picker/index.scss
+++ b/packages/nutui/components/picker/index.scss
@@ -2,24 +2,15 @@
 
 .nut-theme-dark {
   .nut-picker {
-    position: relative;
-    width: 100%;
     background: $dark-background;
-    border-radius: 5px;
 
     /* #ifndef H5 */
+
     &__mask {
       background: none !important;
     }
 
     /* #endif */
-
-    &__bar {
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      height: 46px;
-    }
 
     &__title {
       color: $dark-color;

--- a/packages/nutui/components/picker/index.scss
+++ b/packages/nutui/components/picker/index.scss
@@ -3,6 +3,7 @@
 .nut-theme-dark {
   .nut-picker {
     position: relative;
+    width: 100%;
     background: $dark-background;
     border-radius: 5px;
 
@@ -36,6 +37,7 @@
 
 .nut-picker {
   position: relative;
+  width: 100%;
   background: #fff;
   border-radius: 5px;
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/nutui-uniapp/nutui-uniapp/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

`picker`组件最外层未指定宽度，如果`picker`被`flex`元素包裹，并且`showToolbar`为`false`时，宽度为0

<!-- Clear and concise description of what the PR is solving. -->

### Linked Issues

<!-- Fix #123. Fix #666. -->

### Additional Context

<!-- Any other context or screenshots about the PR here. -->
