### PR TITLE
fix(hooks): 修复useSelectorQuery在app平台查询节点数据为空的问题

### DIFF
--- a/packages/nutui/components/_hooks/useSelectorQuery.ts
+++ b/packages/nutui/components/_hooks/useSelectorQuery.ts
@@ -10,11 +10,12 @@ export function useSelectorQuery(instance?: ComponentInternalInstance | null) {
   if (!instance)
     console.warn('useSelectorQuery', 'useSelectorQuery必须在setup函数中使用')
 
-  // #ifndef MP-ALIPAY
   query = uni.createSelectorQuery().in(instance)
-  // #endif
   // #ifdef MP-ALIPAY
   query = uni.createSelectorQuery().in(null)
+  // #endif
+  // #ifdef APP-PLUS
+  query = uni.createSelectorQuery()
   // #endif
 
   const getSelectorNodeInfo = (selector: string): Promise<UniApp.NodeInfo> => {

--- a/packages/nutui/components/_hooks/useSelectorQuery.ts
+++ b/packages/nutui/components/_hooks/useSelectorQuery.ts
@@ -10,7 +10,9 @@ export function useSelectorQuery(instance?: ComponentInternalInstance | null) {
   if (!instance)
     console.warn('useSelectorQuery', 'useSelectorQuery必须在setup函数中使用')
 
+  // #ifndef MP-ALIPAY || APP-PLUS
   query = uni.createSelectorQuery().in(instance)
+  // #endif
   // #ifdef MP-ALIPAY
   query = uni.createSelectorQuery().in(null)
   // #endif


### PR DESCRIPTION


<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/nutui-uniapp/nutui-uniapp/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

app平台createSelectorQuery不需要in参数，传入后会获取不到节点数据

<!-- Clear and concise description of what the PR is solving. -->

### Linked Issues

<!-- Fix #123. Fix #666. -->

### Additional Context

<!-- Any other context or screenshots about the PR here. -->
