### PR TITLE
fix(menu): 修复点击菜单无法正常切换的问题

### DIFF
--- a/packages/nutui/components/menu/index.scss
+++ b/packages/nutui/components/menu/index.scss
@@ -23,7 +23,10 @@
     display: flex;
     line-height: $menu-bar-line-height;
     background-color: $white;
-    box-shadow: $menu-bar-box-shadow;
+
+    &:not(.opened) {
+      box-shadow: $menu-bar-box-shadow;
+    }
 
     &.opened {
       z-index: $menu-bar-opened-z-index;
@@ -35,7 +38,7 @@
       font-size: $menu-item-font-size;
       color: $menu-item-text-color;
       text-align: center;
-      
+
 
       &.active {
         color: $menu-item-active-text-color;
@@ -60,9 +63,9 @@
           display: block;
           padding-right: $menu-title-text-padding-right;
           padding-left: $menu-title-text-padding-left;
-          
+
           @include text-ellipsis;
-       
+
         }
 
         &.active .nut-menu__title-icon {

--- a/packages/nutui/components/menuitem/index.scss
+++ b/packages/nutui/components/menuitem/index.scss
@@ -12,7 +12,7 @@
   position: fixed;
   right: 0;
   left: 0;
-  z-index: $menu-bar-opened-z-index;
+  z-index: calc($menu-bar-opened-z-index - 1);
   height: 100vh;
   overflow: hidden;
 
@@ -52,6 +52,6 @@
   position: fixed;
   right: 0;
   left: 0;
-  z-index: $menu-bar-opened-z-index;
+  z-index: calc($menu-bar-opened-z-index - 1);
   background-color: transparent;
 }

--- a/packages/nutui/components/menuitem/menuitem.vue
+++ b/packages/nutui/components/menuitem/menuitem.vue
@@ -56,7 +56,7 @@ export default defineComponent({
       if (parent?.props.direction === 'down')
         return { ...heightStyle, top: 0 }
 
-      return { ...heightStyle, top: 'auto' }
+      return { ...heightStyle, bottom: 0 }
     })
 
     const open = () => {


### PR DESCRIPTION
### 描述
修复了 Menu 组件在切换和关闭菜单时的交互问题。主要解决了以下几个问题：

1. 修复向下展开的菜单需要点击两次才能切换的问题
   - 原因：遮罩层的 z-index 高于菜单项，导致第一次点击实际点击到了遮罩层
   - 解决：调整了遮罩层的 z-index 优先级，确保菜单项可以正常响应点击事件

2. 修复向上展开的菜单点击空白处无法关闭的问题
   - 原因：遮罩层定位不正确，未能完全覆盖需要响应点击的区域
   - 解决：修正了遮罩层的定位逻辑

3. 优化了菜单展开时的样式表现

这些修改确保了菜单可以在一次点击时正常切换，同时保持了点击空白处关闭菜单的功能。

### 关联的 Issues
fix [#448](https://github.com/nutui-uniapp/nutui-uniapp/issues/448)

### 补充说明
该修复改进了 Menu 组件的用户体验，使其行为更符合用户预期：
- 菜单切换时更加流畅，无需多次点击
- 保持了点击空白处关闭菜单的功能
- 统一了向上和向下展开菜单的交互体验