### PR TITLE
fix(transition): 修复部分环境编译报错

### DIFF
--- a/packages/nutui/components/transition/index.ts
+++ b/packages/nutui/components/transition/index.ts
@@ -1,3 +1,3 @@
 export * from './transition'
-export type * from './types'
+export * from './types'
 export * from './use-transition'

--- a/packages/nutui/components/transition/transition.ts
+++ b/packages/nutui/components/transition/transition.ts
@@ -6,7 +6,8 @@ import type { NutAnimationName, NutAnimationtimingFunction } from './types'
 export const transitionProps = {
   ...commonProps,
   /**
-   * @description 内置动画名称，可选值为 `fade` `fade-up` `fade-down` f`ade-left` `fade-right` `slide-up` `slide-down` `slide-left` `slide-right`
+   * @description 内置动画名称，可选值为
+   * `fade` `fade-up` `fade-down` `fade-left` `fade-right` `slide-up` `slide-down` `slide-left` `slide-right`
    */
   name: makeStringProp<NutAnimationName>('fade'),
   /**
@@ -21,6 +22,9 @@ export const transitionProps = {
    * @description 动画函数
    */
   timingFunction: makeStringProp<NutAnimationtimingFunction>('ease'),
+  /**
+   * @description 关闭后是否销毁内容
+   */
   destroyOnClose: Boolean,
   /**
    * @description 进入动画前的类名
@@ -48,6 +52,8 @@ export const transitionProps = {
   leaveToClass: String,
 }
 
+export type TransitionProps = ExtractPropTypes<typeof transitionProps>
+
 export const transitionEmits = {
   beforeEnter: () => true,
   enter: () => true,
@@ -58,5 +64,4 @@ export const transitionEmits = {
   [CLICK_EVENT]: (evt: MouseEvent) => evt instanceof Object,
 }
 
-export type TransitionProps = ExtractPropTypes<typeof transitionProps>
 export type TransitionEmits = typeof transitionEmits

--- a/packages/nutui/components/transition/transition.vue
+++ b/packages/nutui/components/transition/transition.vue
@@ -1,16 +1,19 @@
-<script setup lang="ts">
+<script lang="ts" setup>
 import { defineComponent } from 'vue'
 import { PREFIX } from '../_constants'
 import { transitionEmits, transitionProps } from './transition'
 import { useTransition } from './use-transition'
 
 const props = defineProps(transitionProps)
-const emits = defineEmits(transitionEmits)
-const { display, classes, clickHandler, styles } = useTransition(props, emits)
+
+const emit = defineEmits(transitionEmits)
+
+const { display, classes, styles, clickHandler } = useTransition(props, emit)
 </script>
 
 <script lang="ts">
 const componentName = `${PREFIX}-transition`
+
 export default defineComponent({
   name: componentName,
   options: {
@@ -33,5 +36,5 @@ export default defineComponent({
 </template>
 
 <style lang="scss">
-@import './index';
+@import "./index";
 </style>

--- a/packages/nutui/components/transition/types.ts
+++ b/packages/nutui/components/transition/types.ts
@@ -9,8 +9,10 @@ export interface NutAnimation {
 
 export const nutAnimationName = ['fade', 'fade-up', 'fade-down', 'fade-left', 'fade-right', 'slide-up', 'slide-down', 'slide-left', 'slide-right', 'zoom', 'none'] as const
 export type NutAnimationName = (typeof nutAnimationName)[number]
+
 export const nutAnimationtimingFunction = ['linear', 'ease', 'ease-in', 'ease-in-out', 'ease-out', 'step-start', 'step-end'] as const
 export type NutAnimationtimingFunction = (typeof nutAnimationtimingFunction)[number]
+
 export interface NutAnimations {
   [key: string]: NutAnimation
 }


### PR DESCRIPTION
部分环境中，混合连续使用 `?.` 和 `?:` 导致编译报错 `TypeError: "a" is read-only`

```ts
animationClass.value = defaultAnimations[name.value]?.enter
  ? defaultAnimations[name.value]?.enter
  : `${classNames.value.enter} ${classNames.value.enterActive}`
```

link #461