### PR TITLE
fix(sku): 修复header内插槽的显示判断

### DIFF
--- a/docs/components/business/sku.md
+++ b/docs/components/business/sku.md
@@ -13,6 +13,7 @@
     v-model:visible="base"
     :sku="sku"
     :goods="goods"
+    :btn-options="['cart', 'buy']"
     @selectSku="selectSku"
     @clickBtnOperate="clickBtnOperate"
     @close="close"

--- a/packages/nutui/components/sku/sku.vue
+++ b/packages/nutui/components/sku/sku.vue
@@ -130,11 +130,11 @@ export default defineComponent({
     <view :class="classes" :style="customStyle">
       <slot name="skuHeader">
         <SkuHeader :goods="goods">
-          <template #skuHeaderPrice>
+          <template v-if="getSlots('skuHeaderPrice')" #skuHeaderPrice>
             <slot name="skuHeaderPrice" />
           </template>
 
-          <template #skuHeaderExtra>
+          <template v-if="getSlots('skuHeaderExtra')" #skuHeaderExtra>
             <slot name="skuHeaderExtra" />
           </template>
         </SkuHeader>

--- a/packages/nutui/components/textarea/index.scss
+++ b/packages/nutui/components/textarea/index.scss
@@ -42,7 +42,6 @@
     min-width: 0;
     padding: 0;
     margin: 0;
-    overflow: hidden;
     font-size: $textarea-font;
     line-height: 20px;
     color: $textarea-text-color;
@@ -51,7 +50,7 @@
     background-color: transparent;
     border: none;
     outline: none;
-   
+
     .taro-textarea {
       font-size: 14px;
     }

--- a/packages/nutui/components/textarea/index.scss
+++ b/packages/nutui/components/textarea/index.scss
@@ -42,6 +42,7 @@
     min-width: 0;
     padding: 0;
     margin: 0;
+    overflow: hidden;
     font-size: $textarea-font;
     line-height: 20px;
     color: $textarea-text-color;
@@ -50,7 +51,7 @@
     background-color: transparent;
     border: none;
     outline: none;
-
+   
     .taro-textarea {
       font-size: 14px;
     }


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/nutui-uniapp/nutui-uniapp/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

解决sku在不使用头部skuHeaderPrice和skuHeaderExtra插槽时也会被判断为使用，导致头部插槽右侧不显示的问题

### Linked Issues

 Fix #468 


### Additional Context
![image](https://github.com/user-attachments/assets/f67b5e30-2c10-4b4c-ade1-56a22cba96b5)
