### PR TITLE
fix(textarea): 修复设置了autosize中maxHeight时内容溢出显示问题

### DIFF
--- a/packages/nutui/components/textarea/index.scss
+++ b/packages/nutui/components/textarea/index.scss
@@ -42,6 +42,7 @@
     min-width: 0;
     padding: 0;
     margin: 0;
+    overflow: hidden;
     font-size: $textarea-font;
     line-height: 20px;
     color: $textarea-text-color;


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/nutui-uniapp/nutui-uniapp/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

当textarea设置了autosize属性且maxHeight时，初始绑定的数据“意外”的超出设定的最大高度时，会有溢出显示

### Linked Issues

Fix #466 

### Additional Context
