### PR TITLE
fix(tabs): 修复自定义标签栏找不到元素的报错

### DIFF
--- a/packages/nutui/components/tabs/tabs.vue
+++ b/packages/nutui/components/tabs/tabs.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { ComponentInternalInstance, CSSProperties, Ref, VNode } from 'vue'
-import { computed, defineComponent, getCurrentInstance, nextTick, onActivated, onMounted, ref, watch } from 'vue'
+import { computed, defineComponent, getCurrentInstance, nextTick, onActivated, onMounted, ref, useSlots, watch } from 'vue'
 import { CHANGE_EVENT, CLICK_EVENT, PREFIX, UPDATE_MODEL_EVENT } from '../_constants'
 import { useProvide, useRect, useSelectorQuery } from '../_hooks'
 import { getMainClass, getRandomId, pxCheck, TypeOfFun } from '../_utils'
@@ -75,8 +75,12 @@ const scrollWithAnimation = ref(false)
 const navRectRef = ref()
 const titleRectRef = ref<UniApp.NodeInfo[]>([])
 const canShowLabel = ref(false)
+const slots = useSlots()
+const getSlots = (name: string) => slots[name]
+const hasTabsTitlesSlot = getSlots('titles') != null
+
 function scrollIntoView() {
-  if (!props.titleScroll)
+  if (!props.titleScroll || hasTabsTitlesSlot)
     return
   raf(() => {
     Promise.all([

--- a/packages/nutui/components/tabs/tabs.vue
+++ b/packages/nutui/components/tabs/tabs.vue
@@ -10,17 +10,26 @@ import { useTabContentTouch } from './hooks'
 import { TAB_KEY, tabsEmits, tabsProps, Title } from './tabs'
 
 const props = defineProps(tabsProps)
+
 const emit = defineEmits(tabsEmits)
+
+const slots = useSlots()
+
 const instance = getCurrentInstance() as ComponentInternalInstance
 const { getSelectorNodeInfo, getSelectorNodeInfos } = useSelectorQuery(instance)
+
 const refRandomId = getRandomId()
+
 const container = ref(null)
+
 const { internalChildren } = useProvide(TAB_KEY, `${PREFIX}-tabs`)({
   activeKey: computed(() => props.modelValue || 0),
   autoHeight: computed(() => props.autoHeight),
   animatedTime: computed(() => props.animatedTime),
 })
+
 const titles: Ref<Title[]> = ref([])
+
 function renderTitles(vnodes: VNode[]) {
   vnodes.forEach((vnode: VNode, index: number) => {
     let type = vnode.type
@@ -51,6 +60,7 @@ function renderTitles(vnodes: VNode[]) {
 }
 
 const currentIndex = ref((props.modelValue as number) || 0)
+
 function findTabsIndex(value: string | number) {
   const index = titles.value.findIndex(item => item.paneKey === String(value))
   // if (titles.value.length === 0)
@@ -62,12 +72,15 @@ function findTabsIndex(value: string | number) {
   // else
   currentIndex.value = index
 }
+
 const getScrollX = computed(() => {
   return props.titleScroll && props.direction === 'horizontal'
 })
+
 const getScrollY = computed(() => {
   return props.titleScroll && props.direction === 'vertical'
 })
+
 const titleRef = ref([]) as Ref<HTMLElement[]>
 const scrollLeft = ref(0)
 const scrollTop = ref(0)
@@ -75,12 +88,9 @@ const scrollWithAnimation = ref(false)
 const navRectRef = ref()
 const titleRectRef = ref<UniApp.NodeInfo[]>([])
 const canShowLabel = ref(false)
-const slots = useSlots()
-const getSlots = (name: string) => slots[name]
-const hasTabsTitlesSlot = getSlots('titles') != null
 
 function scrollIntoView() {
-  if (!props.titleScroll || hasTabsTitlesSlot)
+  if (!props.titleScroll || slots.titles)
     return
   raf(() => {
     Promise.all([


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/nutui-uniapp/nutui-uniapp/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
修复自定义标签栏找不到元素的报错
![image](https://github.com/user-attachments/assets/5d4cf7ab-55ae-4dcb-a222-3d9a546eca61)


### Linked Issues

<!-- Fix #123. Fix #666. -->

### Additional Context

其实我觉得这个自定义标签栏的颗粒度不对，如果只是想修改的item内部显示（很常见的需求），那设置的title-scroll属性就直接失效了，滚动效果和动效就直接没了
