### PR TITLE
fix(sku-header): 简化 skuheader.vue 中的 <image> 渲染逻辑，移除无效的 isH5 判断

### DIFF
--- a/packages/nutui/components/skuheader/skuheader.vue
+++ b/packages/nutui/components/skuheader/skuheader.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { defineComponent, useSlots } from 'vue'
 import { PREFIX } from '../_constants'
-import { isH5 } from '../_utils'
 import { useTranslate } from '../../locale'
 import NutPrice from '../price/price.vue'
 
@@ -34,8 +33,7 @@ export default defineComponent ({
 
 <template>
   <view class="nut-sku-header">
-    <image v-if="!isH5" class="nut-sku-header-img" :src="goods.imagePath" />
-    <image v-else class="nut-sku-header-img" :src="goods.imagePath" />
+    <image class="nut-sku-header-img" :src="goods.imagePath" />
     <view class="nut-sku-header-right">
       <template v-if="getSlots('skuHeaderPrice')">
         <slot name="skuHeaderPrice" />


### PR DESCRIPTION
原先 <image> 标签根据 isH5 进行了 v-if/v-else 判断，但两者渲染内容完全一致，属于冗余逻辑。

变更内容：
- 移除了对 isH5 的无效判断
- 使用一行 <image> 标签进行渲染

<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/nutui-uniapp/nutui-uniapp/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Clear and concise description of what the PR is solving. -->

### Linked Issues

<!-- Fix #123. Fix #666. -->

### Additional Context

<!-- Any other context or screenshots about the PR here. -->
